### PR TITLE
Ensure generate_guid returns a string

### DIFF
--- a/benchmark/bench.rb
+++ b/benchmark/bench.rb
@@ -10,7 +10,7 @@ tracer = LightStep.init_new_tracer('lightstep/ruby/spec', '{your_access_token}',
 
 Benchmark.bm(32) do |x|
   x.report('Random.bytes.unpack') do
-    for i in 1..10_000; rng.bytes(8).unpack('H*'); end
+    for i in 1..10_000; rng.bytes(8).unpack('H*')[0]; end
   end
   x.report('Random.bytes.each_byte.map') do
     for i in 1..10_000; rng.bytes(8).each_byte.map { |b| b.to_s(16) }.join; end

--- a/lib/lightstep/tracer/util.rb
+++ b/lib/lightstep/tracer/util.rb
@@ -6,7 +6,7 @@ class Util
   # Returns a random guid. Note: this intentionally does not use SecureRandom,
   # which is slower and cryptographically secure randomness is not required here.
   def generate_guid
-    @rng.bytes(8).unpack('H*')
+    @rng.bytes(8).unpack('H*')[0]
   end
 
   def now_micros

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -52,6 +52,14 @@ describe LightStep do
     span.finish
   end
 
+  it 'should generate string span guids' do
+    tracer = init_test_tracer
+    span = tracer.start_span('test_span')
+
+    expect(span.guid).to be_an_instance_of String
+    span.finish
+  end
+
   it 'should handle all valid payloads types' do
     tracer = init_test_tracer
     span = tracer.start_span('test_span')


### PR DESCRIPTION
- Fixes a defect where the internal `generate_guid` method was returning a single-element array containing a string guid, not just a string guid
- Add unit tests to confirm that span guids are strings
