### PR TITLE
Add inject/join for FORMAT_TEXT_MAP

### DIFF
--- a/benchmark/bench.rb
+++ b/benchmark/bench.rb
@@ -44,4 +44,13 @@ Benchmark.bm(32) do |x|
     for i in 0..10_000; span.log_event('event', i); end
     span.finish
   end
+
+  x.report('inject(10000)') do
+    span = tracer.start_span('my_span')
+    for i in 0..10_000
+      carrier = {}
+      tracer.inject(span, LightStep.FORMAT_TEXT_MAP, carrier)
+     end
+    span.finish
+  end
 end

--- a/lib/lightstep-tracer.rb
+++ b/lib/lightstep-tracer.rb
@@ -1,17 +1,18 @@
 require_relative './lightstep/tracer/thrift/types'
 require_relative './lightstep/tracer/client_tracer'
+require_relative './lightstep/tracer/constants'
 
 module LightStep
   @@instance = nil
 
-  # Initializes and returns the singleton instance of the Tracer.
-  # For convenience, multiple calls to initialize are allowed. For example,
-  # in library code with more than possible first entry-point, this may
-  # be helpful.
-  #
-  # @return LightStepBase_Tracer
-  # @throws Exception if the component name or access token is not a valid string
-  # @throws Exception if the tracer singleton has already been initialized
+  def self.FORMAT_TEXT_MAP
+    Lightstep::Tracer::FORMAT_TEXT_MAP
+  end
+
+  def self.FORMAT_BINARY
+    Lightstep::Tracer::FORMAT_BINARY
+  end
+
   def self.init_global_tracer(component_name, access_token, opts = nil)
     if component_name.class.name != 'String' || component_name.empty?
       puts "Invalid component_name: #{component_name}"

--- a/lib/lightstep/tracer/constants.rb
+++ b/lib/lightstep/tracer/constants.rb
@@ -1,0 +1,9 @@
+module Lightstep
+  module Tracer
+    FORMAT_TEXT_MAP = 1
+    FORMAT_BINARY = 2
+
+    CARRIER_TRACER_STATE_PREFIX = 'ot-tracer-'.freeze
+    CARRIER_BAGGAGE_PREFIX = 'ot-baggage-'.freeze
+  end
+end


### PR DESCRIPTION
- Adds inject / join for `FORMAT_TEXT_MAP`
- (Does not add binary format support yet)
- Adds a trivial unit test for inject/join on the text format
- Fixes a defect in the internal counters map not being reset between reports
- Moves around some code to keep the OpenTracing centric vs implementation specific chunks of code more cleanly delineated
