### PR TITLE
Flush at finalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ sleep(0.2)
 child.finish
 sleep(0.1)
 span.finish
-
-# Flush any enqueued data before program exit
-LightStep.instance.flush
 ```
 
 ## Development

--- a/example.rb
+++ b/example.rb
@@ -16,5 +16,4 @@ child.finish
 sleep(0.1)
 span.finish
 
-LightStep.instance.flush
 puts 'Done!'

--- a/lib/lightstep/tracer/client_tracer.rb
+++ b/lib/lightstep/tracer/client_tracer.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'weakref'
 
 require_relative './constants'
 require_relative './client_span'
@@ -118,6 +119,8 @@ class ClientTracer
     @tracer_start_time = @tracer_utils.now_micros
     @tracer_report_start_time = @tracer_start_time
     @tracer_last_flush_micros = @tracer_start_time
+
+    ObjectSpace.define_finalizer(WeakRef.new(self), proc { flush })
   end
 
   def finalize


### PR DESCRIPTION
- Use the `ObjectSpace` finalizer to ensure Tracer instances flush at exit.
