### PR TITLE
Move HTTP calls into separate thread. Include flush at exit.

### DIFF
--- a/lib/lightstep/tracer/client_span.rb
+++ b/lib/lightstep/tracer/client_span.rb
@@ -89,6 +89,10 @@ class ClientSpan
     @tags[:parent_span_guid]
   end
 
+  def generate_trace_url
+    "https://app.lightstep.com/#{@tracer.access_token}/trace?span_guid=#{@guid}&at_micros=#{start_micros}"
+  end
+
   def set_parent(span)
     set_tag(:parent_span_guid, span.guid)
     set_tag('join:trace_id', span.tags['join:trace_id'])

--- a/lib/lightstep/tracer/transports/transport_callback.rb
+++ b/lib/lightstep/tracer/transports/transport_callback.rb
@@ -15,4 +15,7 @@ class TransportCallback
     @callback.call(content)
     nil
   end
+
+  def close
+  end
 end

--- a/lib/lightstep/tracer/transports/transport_http_json.rb
+++ b/lib/lightstep/tracer/transports/transport_http_json.rb
@@ -1,24 +1,30 @@
 require 'json'
 require 'zlib'
 require 'net/http'
+require 'thread'
 require_relative './util'
 
 class TransportHTTPJSON
   def initialize
+    # Configuration
     @host = ''
     @port = 0
     @verbose = 0
     @secure = true
+
+    # Network requests occur off the calling thread
+    # Note: this is a rather minimal approach to getting reporting tasks off the
+    # calling thread. If the network thread falls behind by > the queue size,
+    # it will start slowing down the calling thread.
+    @queue = SizedQueue.new(16)
+    @thread = _start_network_thread
   end
 
   def ensure_connection(options)
     @verbose = options[:verbose]
     @host = options[:collector_host]
     @port = options[:collector_port]
-    @secure = true
-
-    # The prefixed protocol is only needed for secure connections
-    @secure = false if options[:collector_encryption] == 'none'
+    @secure = (options[:collector_encryption] != 'none')
   end
 
   def flush_report(auth, report)
@@ -31,14 +37,58 @@ class TransportHTTPJSON
     content = _thrift_struct_to_object(report)
     # content = Zlib::deflate(content)
 
-    https = Net::HTTP.new(@host, @port)
-    https.use_ssl = @secure
+    @queue << {
+      host: @host,
+      port: @port,
+      secure: @secure,
+      access_token: auth.access_token,
+      content: content,
+      verbose: @verbose
+    }
+    nil
+  end
+
+  def close
+    # Since close can be called at shutdown and there are multiple Ruby
+    # interpreters out there, don't assume the shutdown process will leave the
+    # thread alive or have definitely killed it
+    if @thread.alive?
+      @queue << { signal_exit: true }
+      @thread.join
+    elsif !@queue.empty?
+      begin
+        _post_report(@queue.pop(true))
+      rescue
+        # Ignore the error. Make sure this final flush does not percollate an
+        # exception back into the calling code.
+      end
+    end
+  end
+
+  def _start_network_thread
+    Thread.new do
+      done = false
+      until done
+        params = @queue.pop
+        if params[:signal_exit]
+          done = true
+        else
+          _post_report(params)
+        end
+      end
+    end
+  end
+
+  def _post_report(params)
+    https = Net::HTTP.new(params[:host], params[:port])
+    https.use_ssl = params[:secure]
     req = Net::HTTP::Post.new('/api/v0/reports')
-    req['LightStep-Access-Token'] = auth.access_token
+    req['LightStep-Access-Token'] = params[:access_token]
     req['Content-Type'] = 'application/json'
     req['Connection'] = 'keep-alive'
-    req.body = content.to_json
+    req.body = params[:content].to_json
     res = https.request(req)
-    nil
+
+    puts res.to_s if params[:verbose] >= 3
   end
 end

--- a/lib/lightstep/tracer/transports/transport_nil.rb
+++ b/lib/lightstep/tracer/transports/transport_nil.rb
@@ -9,4 +9,7 @@ class TransportNil
   def flush_report(_auth, _report)
     nil
   end
+
+  def close
+  end
 end


### PR DESCRIPTION
- Moves the reporting HTTP call to a separate thread as to not block the calling thread on network I/O
- Adds a `generate_trace_url` utility method to Span
- Updates the flush at exit to work with the multi-threaded code
