### PR TITLE
Fix overly low reporting period defaults

### DIFF
--- a/benchmark/threading/thread_test.rb
+++ b/benchmark/threading/thread_test.rb
@@ -1,0 +1,53 @@
+require_relative '../../lib/lightstep-tracer.rb'
+require 'thread'
+
+LightStep.init_global_tracer('lightstep/ruby/example', '{your_access_token}')
+
+puts 'Starting...'
+
+mutex = Mutex.new
+done = false
+span_count = 0
+percent_done = 0
+total_time = 0
+
+watchThread = Thread.new do
+  loop do
+    sleep(3.0)
+    mutex.lock
+    time_per_span = (1e6 * (total_time.to_f / span_count.to_f)).round(2)
+    puts "#{span_count} spans #{percent_done}% done #{total_time.round(2)} seconds (#{time_per_span} us/span)"
+    is_done = done
+    mutex.unlock
+    Thread.exit if is_done
+  end
+end
+
+thread = Thread.new do
+  count = 0
+  total_time = 0
+  for j in 1..1000
+    start = Time.now
+    for i in 1..100
+      span = LightStep.start_span('my_span')
+      span.log_event('hello world', count: i)
+      span.finish
+      count += 1
+    end
+    delta = Time.now - start
+
+    mutex.lock
+    percent_done = (100.0 * (count / 100_000.0)).ceil
+    span_count = count
+    total_time += delta
+    mutex.unlock
+  end
+end
+
+thread.join
+mutex.lock
+done = true
+mutex.unlock
+watchThread.join
+
+puts 'Done!'

--- a/lib/lightstep/tracer/client_tracer.rb
+++ b/lib/lightstep/tracer/client_tracer.rb
@@ -76,8 +76,8 @@ class ClientTracer
       dropped_spans: 0
     }
     @tracer_last_flush_micros = 0
-    @tracer_min_flush_period_micros = 500 * 1000
-    @tracer_max_flush_period_micros = 30_000 * 1000
+    @tracer_min_flush_period_micros = 0 # Initialized below by the default options
+    @tracer_max_flush_period_micros = 0 # Initialized below by the default options
 
     @tracer_defaults = {
       collector_host: 'collector.lightstep.com',
@@ -86,8 +86,8 @@ class ClientTracer
       transport: 'http_json',
       max_log_records: 1000,
       max_span_records: 1000,
-      min_reporting_period_secs: 0.1,
-      max_reporting_period_secs: 5.0,
+      min_reporting_period_secs: 1.5,
+      max_reporting_period_secs: 30.0,
 
       max_payload_depth: 10,
 
@@ -325,8 +325,6 @@ class ClientTracer
     end
   end
 
-  # PHP does not have an event loop or timer threads. Instead manually check as
-  # new data comes in by calling this method.
   def flush_if_needed
     return unless @tracer_enabled
 
@@ -339,8 +337,8 @@ class ClientTracer
     # Look for a trigger that a flush is warranted
     # Set a bound of minimum flush frequency
     if delta > @tracer_max_flush_period_micros ||
-       @tracer_log_records.length >= @tracer_options[:max_log_records] ||
-       @tracer_span_records.length >= @tracer_options[:max_span_records]
+       @tracer_log_records.length >= @tracer_options[:max_log_records] / 2 ||
+       @tracer_span_records.length >= @tracer_options[:max_span_records] / 2
       flush
     end
   end


### PR DESCRIPTION
## Summary
- Fix a "bad" default that was causing Ruby to try to report too often (and thus incur too much overhead)
- Adds a manual benchmark on span creation
