### PR TITLE
Update to use trace_guid field

### DIFF
--- a/lib/lightstep/tracer/client_span.rb
+++ b/lib/lightstep/tracer/client_span.rb
@@ -47,6 +47,7 @@ class ClientSpan
   def initialize(tracer)
     @guid = ''
     @operation = ''
+    @trace_guid = nil
     @tags = {}
     @baggage = {}
     @start_micros = 0
@@ -58,6 +59,7 @@ class ClientSpan
   end
 
   attr_reader :guid, :operation, :tags, :baggage, :start_micros, :end_micros, :error_flag
+  attr_accessor :trace_guid
 
   def finalize
     if @end_micros == 0
@@ -81,10 +83,6 @@ class ClientSpan
     self
   end
 
-  def trace_guid
-    @tags['join:trace_id']
-  end
-
   def parent_guid
     @tags[:parent_span_guid]
   end
@@ -95,7 +93,7 @@ class ClientSpan
 
   def set_parent(span)
     set_tag(:parent_span_guid, span.guid)
-    set_tag('join:trace_id', span.tags['join:trace_id'])
+    @trace_guid = span.trace_guid
     self
   end
 

--- a/lib/lightstep/tracer/client_tracer.rb
+++ b/lib/lightstep/tracer/client_tracer.rb
@@ -19,7 +19,6 @@ class ClientTracer
     span = ClientSpan.new(self)
     span.set_operation_name(operation_name)
     span.set_start_micros(@tracer_utils.now_micros)
-    span.set_tag('join:trace_id', generate_uuid_string)
 
     unless fields.nil?
       span.set_parent(fields[:parent]) unless fields[:parent].nil?
@@ -28,6 +27,8 @@ class ClientTracer
         span.set_start_micros(fields[:startTime] * 1000)
       end
     end
+
+    span.trace_guid = generate_uuid_string if span.trace_guid.nil?
     span
   end
 
@@ -171,7 +172,7 @@ class ClientTracer
 
     parent_guid = carrier[Lightstep::Tracer::CARRIER_TRACER_STATE_PREFIX + 'spanid']
     trace_guid = carrier[Lightstep::Tracer::CARRIER_TRACER_STATE_PREFIX + 'traceid']
-    span.set_tag('join:trace_id', trace_guid)
+    span.trace_guid = trace_guid
     span.set_tag(:parent_span_guid, parent_guid)
 
     carrier.each do |key, value|

--- a/lib/lightstep/tracer/thrift/crouton_types.rb
+++ b/lib/lightstep/tracer/thrift/crouton_types.rb
@@ -129,6 +129,7 @@ end
 class SpanRecord
   include ::Thrift::Struct, ::Thrift::Struct_Union
   SPAN_GUID = 1
+  TRACE_GUID = 11
   RUNTIME_GUID = 2
   SPAN_NAME = 3
   JOIN_IDS = 4
@@ -140,6 +141,7 @@ class SpanRecord
 
   FIELDS = {
     SPAN_GUID => {:type => ::Thrift::Types::STRING, :name => 'span_guid', :optional => true},
+    TRACE_GUID => {:type => ::Thrift::Types::STRING, :name => 'trace_guid', :optional => true},
     RUNTIME_GUID => {:type => ::Thrift::Types::STRING, :name => 'runtime_guid', :optional => true},
     SPAN_NAME => {:type => ::Thrift::Types::STRING, :name => 'span_name', :optional => true},
     JOIN_IDS => {:type => ::Thrift::Types::LIST, :name => 'join_ids', :element => {:type => ::Thrift::Types::STRUCT, :class => ::TraceJoinId}, :optional => true},


### PR DESCRIPTION
Updates the LightStep Thrift structures and uses the new `trace_guid` field in place of the old-style `join:trace_id` tag convention.
