### PR TITLE
Automatically restart the background thread when necessary

### DIFF
--- a/lib/lightstep/tracer/transports/transport_http_json.rb
+++ b/lib/lightstep/tracer/transports/transport_http_json.rb
@@ -25,6 +25,10 @@ class TransportHTTPJSON
     @host = options[:collector_host]
     @port = options[:collector_port]
     @secure = (options[:collector_encryption] != 'none')
+
+    # Forking a worker process may kill the background thread; restart it as
+    # necessary
+    @thread = _start_network_thread unless @thread.alive?
   end
 
   def flush_report(auth, report)


### PR DESCRIPTION
On calls such as `fork` the background network reporting thread can be killed. To keep the behavior correct (i.e. rather than having the forked processes queue up spans without ever reporting), the thread status is now checked before flushes and background thread is recreated as necessary.
