### PR TITLE
Revert "Automatically restart the background thread when necessary"

### DIFF
--- a/lib/lightstep/tracer/transports/transport_http_json.rb
+++ b/lib/lightstep/tracer/transports/transport_http_json.rb
@@ -25,10 +25,6 @@ class TransportHTTPJSON
     @host = options[:collector_host]
     @port = options[:collector_port]
     @secure = (options[:collector_encryption] != 'none')
-
-    # Forking a worker process may kill the background thread; restart it as
-    # necessary
-    @thread = _start_network_thread unless @thread.alive?
   end
 
   def flush_report(auth, report)


### PR DESCRIPTION
Reverts lightstep/lightstep-tracer-ruby#15

Reverting as `SizedQueue` does not survive the `fork`, making this code still unsafe.
