### PR TITLE
Add disable / enable functionality on the tracer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ build:
 test:
 	rake spec
 	ruby example.rb
+	ruby examples/fork_children/main.rb
 
 benchmark:
 	ruby benchmark/bench.rb

--- a/examples/fork_children/main.rb
+++ b/examples/fork_children/main.rb
@@ -1,0 +1,40 @@
+# A simple, manual test ensuring that tracer instances still report after a Process.fork.
+# Currently this requires the tracer instance to be explicitly disabled before the fork
+# and reenabled afterward.
+#
+require_relative '../../lib/lightstep-tracer.rb'
+require 'thread'
+
+LightStep.init_global_tracer('lightstep/ruby/examples/fork_children', '{your_access_token}')
+
+puts 'Starting...'
+for k in 1..20
+  puts "Iteration #{k}..."
+
+  # NOTE: the tracer is disabled and reenalbed on either side of the fork
+  LightStep.disable
+  pid = Process.fork do
+    LightStep.enable
+
+    puts "Child, pid #{Process.pid}"
+    for i in 1..10
+      span = LightStep.start_span("my_forked_span-#{Process.pid}")
+      sleep(0.0025 * rand(k))
+      span.finish
+    end
+    puts 'Child done'
+  end
+
+  # Also renable the parent process' tracer
+  LightStep.enable
+
+  for i in 1..10
+    span = LightStep.start_span("my_process_span-#{Process.pid}")
+    sleep(0.0025 * rand(k))
+    span.finish
+  end
+
+  puts "Parent, pid #{Process.pid}, waiting on child pid #{pid}"
+  Process.wait
+end
+puts 'Exiting'

--- a/examples/fork_children/main.rb
+++ b/examples/fork_children/main.rb
@@ -34,7 +34,21 @@ for k in 1..20
     span.finish
   end
 
+  # Make sure redundant enable calls don't cause problems
+  for i in 1..10
+    LightStep.disable
+    LightStep.enable
+    LightStep.disable
+    LightStep.disable
+    LightStep.enable
+    LightStep.enable
+    span = LightStep.start_span("my_toggle_span-#{Process.pid}")
+    sleep(0.0025 * rand(k))
+    span.finish
+  end
+
   puts "Parent, pid #{Process.pid}, waiting on child pid #{pid}"
   Process.wait
 end
+
 puts 'Exiting'

--- a/lib/lightstep-tracer.rb
+++ b/lib/lightstep-tracer.rb
@@ -56,6 +56,19 @@ module LightStep
     instance.start_span(operation_name, fields)
   end
 
+  # Moves the tracer into a disabled state: the reporting loop is immediately
+  # stopped and spans finished or started in the disabled state will not be
+  # reported.
+  def self.disable
+    instance.disable
+  end
+
+  # Reenables the tracer after a call to disable. This recreates the reporting
+  # thread and it is again valid to start and finish new spans.
+  def self.enable
+    instance.enable
+  end
+
   def self.flush
     instance.flush
    end

--- a/lib/lightstep/tracer/transports/transport_callback.rb
+++ b/lib/lightstep/tracer/transports/transport_callback.rb
@@ -16,6 +16,6 @@ class TransportCallback
     nil
   end
 
-  def close
+  def close(immediate)
   end
 end

--- a/lib/lightstep/tracer/transports/transport_nil.rb
+++ b/lib/lightstep/tracer/transports/transport_nil.rb
@@ -10,6 +10,6 @@ class TransportNil
     nil
   end
 
-  def close
+  def close(immediate)
   end
 end

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -264,4 +264,10 @@ describe LightStep do
       expect(r['log_records'].length).to eq(16 * 10)
     end
   end
+
+  # NOTE: this is a relatively weak test since it is using the test transport
+  # which is very simply (rather than the actual HTTP transport and background
+  # thread).
+  it 'should support disable and enable in sequence' do
+  end
 end

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -269,5 +269,18 @@ describe LightStep do
   # which is very simply (rather than the actual HTTP transport and background
   # thread).
   it 'should support disable and enable in sequence' do
+    tracer = init_callback_tracer(proc { |obj|; result = obj; })
+    for i in 1..4
+      tracer.disable
+      tracer.enable
+    end
+
+    tracer.disable
+    tracer.disable
+    tracer.disable
+
+    tracer.enable
+    tracer.enable
+    tracer.enable
   end
 end


### PR DESCRIPTION
## Summary

Adds two methods to the `ClientTracer`. Note these are LightStep-specific methods, not part of the OpenTracing standard:
- `disable` - stops the background reporting thread and ignores newly finished spans (while in this state)
- `enable` - recreates the background reporting thread and enqueues span data normally

The addition is motivated by a problem where the `SizeQueue` can fall into a corrupt state after a call to `Process.fork`.  Calling `disable` then, on the other side of the fork (for both the child and the parent), circumvents this issue. 

This also adds a manual test program to ensure the behavior is as expected. (It is unfortunately manual as the unit testing uses a mock transport rather than the actual reporting thread.)
