### PR TITLE
Fix defect with payloads with circular references

### DIFF
--- a/examples/rack/hello.rb
+++ b/examples/rack/hello.rb
@@ -1,0 +1,18 @@
+require_relative '../../lib/lightstep-tracer.rb'
+
+require 'rack'
+require 'rack/server'
+
+LightStep.init_global_tracer('lightstep/ruby/examples/rack', '{your_access_token}')
+
+class HelloWorldApp
+  def self.call(env)
+    span = LightStep.start_span('request')
+    span.log_event 'env', env
+    resp = [200, {}, ["Hello World. You said: #{env['QUERY_STRING']}"]]
+    span.finish
+    resp
+  end
+end
+
+Rack::Server.start app: HelloWorldApp


### PR DESCRIPTION
## Summary

Fixes a defect where any exception caused by circular references in payloads would escape into the calling code.

Changes:
- Set a reasonable default max_depth on payload JSON
-  `rescue` on `JSON.generate` failures (by design, the LightStep client libraries drop un-encodable payloads and should not affect the calling code)
- Add a unit test for circular references
- Add a few more test cases to the existing log payload unit test
- Add a trivial Rake server example that creates a span per request
