### PR TITLE
Add support for explicit end time on spans

### DIFF
--- a/lib/lightstep/tracer/client_span.rb
+++ b/lib/lightstep/tracer/client_span.rb
@@ -73,8 +73,8 @@ class ClientSpan
     self
   end
 
-  def set_end_micros(start)
-    @end_micros = start
+  def set_end_micros(micros)
+    @end_micros = micros
     self
   end
 

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -67,6 +67,23 @@ describe LightStep do
     span.finish
   end
 
+  it 'should allow start and end times to be specified explicitly' do
+    tracer = init_test_tracer
+
+    span1 = tracer.start_span('test1', startTime: 1000)
+    span1.finish
+    expect(span1.start_micros).to eq(1000 * 1000)
+
+    span2 = tracer.start_span('test2', endTime: 54_321)
+    span2.finish
+    expect(span2.end_micros).to eq(54_321 * 1000)
+
+    span3 = tracer.start_span('test3', startTime: 1234, endTime: 5678)
+    span3.finish
+    expect(span3.start_micros).to eq(1234 * 1000)
+    expect(span3.end_micros).to eq(5678 * 1000)
+  end
+
   it 'should assign the same trace_guid to child spans as the parent' do
     tracer = init_test_tracer
     parent1 = tracer.start_span('parent1')


### PR DESCRIPTION
## Summary

Adds support for creating spans with explicit end times.  The start and end times are specified in milliseconds.

As a quick example, here's the added unit test for the support:

``` ruby
    span3 = tracer.start_span('test3', startTime: 1234, endTime: 5678)
    span3.finish
    expect(span3.start_micros).to eq(1234 * 1000)
    expect(span3.end_micros).to eq(5678 * 1000)
```
