### PR TITLE
Allow end time to be specified on finish

### DIFF
--- a/lib/lightstep/tracer/client_span.rb
+++ b/lib/lightstep/tracer/client_span.rb
@@ -36,8 +36,12 @@ class ClientSpan
     @tracer.raw_log_record(record, fields[:payload])
   end
 
-  def finish
+  def finish(fields = nil)
+    unless fields.nil?
+      set_end_micros(fields[:endTime] * 1000) unless fields[:endTime].nil?
+    end
     @tracer._finish_span(self)
+    self
   end
 
   # ----------------------------------------------------------------------------

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -84,6 +84,14 @@ describe LightStep do
     expect(span3.end_micros).to eq(5678 * 1000)
   end
 
+  it 'should allow end time to be specified at finish time' do
+    tracer = init_test_tracer
+
+    span = tracer.start_span('test')
+    span.finish(endTime: 54_321)
+    expect(span.end_micros).to eq(54_321 * 1000)
+  end
+
   it 'should assign the same trace_guid to child spans as the parent' do
     tracer = init_test_tracer
     parent1 = tracer.start_span('parent1')


### PR DESCRIPTION
## Summary

Allow the span end time to be specified at finish as well (time is again in milliseconds):

``` ruby
    span = tracer.start_span('test')
    span.finish(endTime: 54_321)
    expect(span.end_micros).to eq(54_321 * 1000)
```
