### PR TITLE
Don't reenable the tracer when calling #enabled?

### DIFF
--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -133,7 +133,8 @@ module LightStep
 
     # @return true if the tracer is enabled
     def enabled?
-      @enabled ||= true
+      return @enabled if defined?(@enabled)
+      @enabled = true
     end
 
     # Enables the tracer

--- a/lightstep.gemspec
+++ b/lightstep.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'bump', '~> 0.5'
   spec.add_development_dependency 'simplecov', '~> 0.12.0'
+  spec.add_development_dependency 'timecop', '~> 0.8.0'
 end

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -334,6 +334,22 @@ describe LightStep do
     tracer.enable
   end
 
+  it 'should not be enabled after disabling' do
+    tracer = init_callback_tracer(proc { |obj| result = obj })
+    tracer.disable
+    expect(tracer).not_to be_enabled
+  end
+
+  it 'should not report spans when disabled' do
+    result = nil
+    tracer = init_callback_tracer(proc { |obj| result = obj })
+    tracer.disable
+    Timecop.freeze(Time.now + 5 * 60) do
+      tracer.start_span('span').finish
+    end
+    expect(result).to be_nil
+  end
+
   it 'should report dropped spans and logs' do
     result = nil
     tracer = init_callback_tracer(proc { |obj| result = obj })

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ require 'simplecov'
 SimpleCov.start
 require 'pp'
 require 'lightstep'
+require 'timecop'
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
Calling `#enabled?` would reenable the tracer. This also meant that `Span#finish` would end up causing spans to be flushed (because internally we'd call `enabled?` and then proceed).