### PR TITLE
Extract Reporting and Merge Buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ The LightStep Tracer is threadsafe. For increased performance, you can add the
 `concurrent-ruby-ext` gem to your Gemfile. This will enable C extensions for
 concurrent operations.
 
-**The LightStep Tracer is not inherently Fork-safe**. When forking, you should
-`disable` the Tracer before forking, then `enable` it in the child Process
-and parent Process after forking. See the `fork_children` example for more.
+The LightStep Tracer is also Fork-safe. When forking, the child process will
+not inherit the unflushed spans of the parent, so they will only be flushed
+once.
 
 ## Development
 

--- a/examples/fork_children/main.rb
+++ b/examples/fork_children/main.rb
@@ -1,6 +1,5 @@
 # A simple, manual test ensuring that tracer instances still report after a
-# Process.fork. Currently this requires the tracer instance to be explicitly
-# disabled before the fork and reenabled afterward.
+# Process.fork.
 
 require 'bundler/setup'
 require 'lightstep'
@@ -14,19 +13,13 @@ puts 'Starting...'
 (1..20).each do |k|
   puts "Explicit reset iteration #{k}..."
 
-  # NOTE: the tracer is disabled and reenabled on either side of the fork
-  LightStep.disable
   pid = Process.fork do
-    LightStep.enable
     10.times do
       span = LightStep.start_span("my_forked_span-#{Process.pid}")
       sleep(0.0025 * rand(k))
       span.finish
     end
   end
-
-  # Also renable the parent process' tracer
-  LightStep.enable
 
   10.times do
     span = LightStep.start_span("my_process_span-#{Process.pid}")
@@ -35,6 +28,8 @@ puts 'Starting...'
   end
 
   # Make sure redundant enable calls don't cause problems
+  # NOTE: disabling discards the buffer by default, so all spans
+  # get cleared here except the final toggle span
   10.times do
     LightStep.disable
     LightStep.enable
@@ -48,7 +43,7 @@ puts 'Starting...'
   end
 
   puts "Parent, pid #{Process.pid}, waiting on child pid #{pid}"
-  Process.wait
+  Process.wait(pid)
 end
 
 puts 'Done!'

--- a/lib/lightstep/global_tracer.rb
+++ b/lib/lightstep/global_tracer.rb
@@ -14,7 +14,7 @@ module LightStep
 
     # Configure the GlobalTracer
     # See {LightStep::Tracer#initialize}
-    def configure(opts = nil)
+    def configure(**options)
       raise ConfigurationError, 'Already configured' if configured
       self.configured = true
       super

--- a/lib/lightstep/reporter.rb
+++ b/lib/lightstep/reporter.rb
@@ -1,0 +1,118 @@
+# Things that will be copied to report:
+# * min/max span records
+# * min/max reporting period
+#
+# Things that move to report:
+# * flushing (finish span just delegates to the reporter)
+# * report runtime data
+# * report timings
+# * at_exit closes the reporter
+# * flush_worker stuff
+
+module LightStep
+  # Reporter builds up reports of spans and flushes them to a transport
+  class Reporter
+    attr_accessor :max_span_records
+
+    def initialize(max_span_records:, transport:, guid:, component_name:)
+      @max_span_records = max_span_records
+      @span_records = Concurrent::Array.new
+      @dropped_spans = Concurrent::AtomicFixnum.new
+      @dropped_span_logs = Concurrent::AtomicFixnum.new
+      @transport = transport
+
+      start_time = LightStep.micros(Time.now)
+      @guid = LightStep.guid
+      @report_start_time = start_time
+      @last_flush_micros = start_time
+
+      @runtime = {
+        guid: guid,
+        start_micros: start_time,
+        group_name: component_name,
+        attrs: [
+          {Key: "lightstep.tracer_platform",         Value: "ruby"},
+          {Key: "lightstep.tracer_version",          Value: LightStep::VERSION},
+          {Key: "lightstep.tracer_platform_version", Value: RUBY_VERSION}
+        ]
+      }.freeze
+
+      # At exit, flush this objects data to the transport and close the transport
+      # (which in turn will send the flushed data over the network).
+      at_exit do
+        flush
+        @transport.close
+      end
+    end
+
+    def flush
+      return if @span_records.empty?
+
+      now = LightStep.micros(Time.now)
+
+      span_records = @span_records.slice!(0, @span_records.length)
+      dropped_spans = 0
+      @dropped_spans.update{|old| dropped_spans = old; 0 }
+
+      old_dropped_span_logs = 0
+      @dropped_span_logs.update{|old| old_dropped_span_logs = old; 0 }
+      dropped_logs = old_dropped_span_logs
+      dropped_logs = span_records.reduce(dropped_logs) do |memo, span|
+        memo += span.delete :dropped_logs
+      end
+
+      report_request = {
+        runtime: @runtime,
+        oldest_micros: @report_start_time,
+        youngest_micros: now,
+        span_records: span_records,
+        counters: [
+            {Name: "dropped_logs",  Value: dropped_logs},
+            {Name: "dropped_spans", Value: dropped_spans},
+        ]
+      }
+
+      @last_flush_micros = now
+      @report_start_time = now
+
+      begin
+        @transport.report(report_request)
+      rescue LightStep::Transport::HTTPJSON::QueueFullError
+        # If the queue is full, add the previous dropped logs to the logs
+        # that were going to get reported, as well as the previous dropped
+        # spans and spans that would have been recorded
+        @dropped_spans.increment(dropped_spans + span_records.length)
+        @dropped_span_logs.increment(old_dropped_span_logs)
+      end
+    end
+
+    def add_span(span)
+      @span_records.push(span.to_h)
+      if @span_records.size > max_span_records
+        @span_records.shift
+        @dropped_spans.increment
+        @dropped_span_logs.increment(span.logs_count + span.dropped_logs_count)
+      end
+      flush_if_needed
+    end
+
+    def clear
+      @transport.clear
+    end
+
+    private
+    MIN_PERIOD_SECS = 1.5
+    MAX_PERIOD_SECS = 30.0
+    MIN_PERIOD_MICROS = MIN_PERIOD_SECS * 1E6
+    MAX_PERIOD_MICROS = MAX_PERIOD_SECS * 1E6
+
+    def flush_if_needed
+      delta = LightStep.micros(Time.now) - @last_flush_micros
+      return if delta < MIN_PERIOD_MICROS
+
+      if delta > MAX_PERIOD_MICROS || @span_records.size >= max_span_records / 2
+        flush
+      end
+    end
+  end
+end

--- a/lib/lightstep/reporter.rb
+++ b/lib/lightstep/reporter.rb
@@ -1,3 +1,5 @@
+require 'concurrent/channel'
+
 module LightStep
   # Reporter builds up reports of spans and flushes them to a transport
   class Reporter
@@ -13,7 +15,6 @@ module LightStep
       start_time = LightStep.micros(Time.now)
       @guid = LightStep.guid
       @report_start_time = start_time
-      @last_flush_micros = start_time
 
       @runtime = {
         guid: guid,
@@ -26,14 +27,64 @@ module LightStep
         ]
       }.freeze
 
-      # At exit, flush this objects data to the transport and close the transport
-      # (which in turn will send the flushed data over the network).
+      reset_on_fork
+
       at_exit do
-        flush
+        @quit_signal << true
+        @thread.join
       end
     end
 
+    def add_span(span)
+      reset_on_fork
+
+      @span_records.push(span.to_h)
+      if @span_records.size > max_span_records
+        dropped = @span_records.shift
+        @dropped_spans.increment
+        @dropped_span_logs.increment(dropped[:log_records].size + dropped[:dropped_logs])
+      end
+
+      @span_signal << true
+    end
+
+    def clear
+      span_records = @span_records.slice!(0, @span_records.length)
+      @dropped_spans.increment(span_records.size)
+      @dropped_span_logs.increment(
+        span_records.reduce(0) {|memo, span|
+          memo + span[:log_records].size + span[:dropped_logs]
+        }
+      )
+    end
+
     def flush
+      @flush_signal << true
+      ~@flush_response_signal
+    end
+
+    private
+    MIN_PERIOD_SECS = 1.5
+    MAX_PERIOD_SECS = 30.0
+
+    # When the process forks, reset the child. All data that was copied will be handled
+    # by the parent. Also, restart the thread since forking killed it
+    def reset_on_fork
+      if @pid != $$
+        @pid = $$
+        @span_signal = Concurrent::Channel.new(buffer: :dropping, capacity: 1)
+        @quit_signal = Concurrent::Channel.new(buffer: :dropping, capacity: 1)
+        @flush_signal = Concurrent::Channel.new
+        @flush_response_signal = Concurrent::Channel.new
+        @span_records.clear
+        @dropped_spans.value = 0
+        @dropped_span_logs.value = 0
+        report_spans
+      end
+    end
+
+    def perform_flush
+      reset_on_fork
       return if @span_records.empty?
 
       now = LightStep.micros(Time.now)
@@ -60,13 +111,12 @@ module LightStep
         ]
       }
 
-      @last_flush_micros = now
       @report_start_time = now
 
       begin
         @transport.report(report_request)
-      rescue LightStep::Transport::HTTPJSON::QueueFullError
-        # If the queue is full, add the previous dropped logs to the logs
+      rescue
+        # an error occurs, add the previous dropped logs to the logs
         # that were going to get reported, as well as the previous dropped
         # spans and spans that would have been recorded
         @dropped_spans.increment(dropped_spans + span_records.length)
@@ -74,38 +124,42 @@ module LightStep
       end
     end
 
-    def add_span(span)
-      @span_records.push(span.to_h)
-      if @span_records.size > max_span_records
-        @span_records.shift
-        @dropped_spans.increment
-        @dropped_span_logs.increment(span.logs_count + span.dropped_logs_count)
-      end
-      flush_if_needed
-    end
-
-    def clear
-      @dropped_spans.increment(@span_records.size)
-      @dropped_span_logs.increment(
-        @span_records.reduce(0) {|memo, span|
-          memo + span[:log_records].size + span[:dropped_logs]
-        }
-      )
-      @span_records.clear
-    end
-
-    private
-    MIN_PERIOD_SECS = 1.5
-    MAX_PERIOD_SECS = 30.0
-    MIN_PERIOD_MICROS = MIN_PERIOD_SECS * 1E6
-    MAX_PERIOD_MICROS = MAX_PERIOD_SECS * 1E6
-
-    def flush_if_needed
-      delta = LightStep.micros(Time.now) - @last_flush_micros
-      return if delta < MIN_PERIOD_MICROS
-
-      if delta > MAX_PERIOD_MICROS || @span_records.size >= max_span_records / 2
-        flush
+    def report_spans
+      @thread = Thread.new do
+        begin
+          loop do
+            min_reached = false
+            max_reached = false
+            min_timer = Concurrent::Channel.timer(MIN_PERIOD_SECS)
+            max_timer = Concurrent::Channel.timer(MAX_PERIOD_SECS)
+            loop do
+              Concurrent::Channel.select do |s|
+                s.take(@span_signal) do
+                  # we'll check span count below
+                end
+                s.take(min_timer) do
+                  min_reached = true
+                end
+                s.take(max_timer) do
+                  max_reached = true
+                end
+                s.take(@quit_signal) do
+                  perform_flush
+                  Thread.exit
+                end
+                s.take(@flush_signal) do
+                  perform_flush
+                  @flush_response_signal << true
+                end
+              end
+              if max_reached || (min_reached && @span_records.size >= max_span_records / 2)
+                perform_flush
+              end
+            end
+          end
+        rescue => ex
+          # TODO: internally log the exception
+        end
       end
     end
   end

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -53,12 +53,12 @@ module LightStep
       @max_span_records = [MIN_MAX_SPAN_RECORDS, max].max
     end
 
-    def min_flush_period_micros
-      @min_flush_period_micros ||= DEFAULT_MIN_REPORTING_PERIOD_SECS * 1E6
+    def min_reporting_period_micros
+      @min_reporting_period_micros ||= DEFAULT_MIN_REPORTING_PERIOD_SECS * 1E6
     end
 
-    def max_flush_period_micros
-      @max_flush_period_micros ||= DEFAULT_MAX_REPORTING_PERIOD_SECS * 1E6
+    def max_reporting_period_micros
+      @max_reporting_period_micros ||= DEFAULT_MAX_REPORTING_PERIOD_SECS * 1E6
     end
 
     # TODO(ngauthier@gmail.com) inherit SpanContext from references
@@ -217,9 +217,9 @@ module LightStep
       return unless enabled?
 
       delta = LightStep.micros(Time.now) - @last_flush_micros
-      return if delta < min_flush_period_micros
+      return if delta < min_reporting_period_micros
 
-      if delta > max_flush_period_micros || @span_records.size >= max_span_records / 2
+      if delta > max_reporting_period_micros || @span_records.size >= max_span_records / 2
         flush
       end
     end

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -57,16 +57,8 @@ module LightStep
       @min_flush_period_micros ||= DEFAULT_MIN_REPORTING_PERIOD_SECS * 1E6
     end
 
-    def min_reporting_period_secs=(secs)
-      @min_flush_period_micros = [DEFAULT_MIN_REPORTING_PERIOD_SECS, secs].max * 1E6
-    end
-
     def max_flush_period_micros
       @max_flush_period_micros ||= DEFAULT_MAX_REPORTING_PERIOD_SECS * 1E6
-    end
-
-    def max_reporting_period_secs=(secs)
-      @max_flush_period_micros = [DEFAULT_MAX_REPORTING_PERIOD_SECS, secs].min * 1E6
     end
 
     # TODO(ngauthier@gmail.com) inherit SpanContext from references

--- a/lib/lightstep/transport/base.rb
+++ b/lib/lightstep/transport/base.rb
@@ -8,15 +8,6 @@ module LightStep
       def report(_report)
         nil
       end
-
-      def close
-      end
-
-      def clear
-      end
-
-      def flush
-      end
     end
   end
 end

--- a/lib/lightstep/transport/callback.rb
+++ b/lib/lightstep/transport/callback.rb
@@ -11,15 +11,6 @@ module LightStep
         @callback.call(report)
         nil
       end
-
-      def close
-      end
-
-      def clear
-      end
-
-      def flush
-      end
     end
   end
 end

--- a/lib/lightstep/transport/http_json.rb
+++ b/lib/lightstep/transport/http_json.rb
@@ -24,7 +24,7 @@ module LightStep
       # @param host [String] host of the domain to the endpoind to push data
       # @param port [Numeric] port on which to connect
       # @param verbose [Numeric] verbosity level. Right now 0-3 are supported
-      # @param secure [Boolean]
+      # @param encryption [ENCRYPTION_TLS, ENCRYPTION_NONE] kind of encryption to use
       # @param access_token [String] access token for LightStep server
       # @return [HTTPJSON]
       def initialize(host: LIGHTSTEP_HOST, port: LIGHTSTEP_PORT, verbose: 0, encryption: ENCRYPTION_TLS, access_token:)

--- a/lib/lightstep/transport/http_json.rb
+++ b/lib/lightstep/transport/http_json.rb
@@ -13,12 +13,9 @@ module LightStep
     class HTTPJSON < Base
       LIGHTSTEP_HOST = "collector.lightstep.com"
       LIGHTSTEP_PORT = 443
-      QUEUE_SIZE = 16
 
       ENCRYPTION_TLS = 'tls'
       ENCRYPTION_NONE = 'none'
-
-      class QueueFullError < LightStep::Error; end
 
       # Initialize the transport
       # @param host [String] host of the domain to the endpoind to push data
@@ -36,75 +33,24 @@ module LightStep
         raise ConfigurationError, "access_token must be a string" unless String === access_token
         raise ConfigurationError, "access_token cannot be blank"  if access_token.empty?
         @access_token = access_token
-
-        start_queue
       end
 
       # Queue a report for sending
       def report(report)
         p report if @verbose >= 3
-        # TODO(ngauthier@gmail.com): the queue could be full here if we're
-        # lagging, which would cause this to block!
-        @queue.push({
-          host: @host,
-          port: @port,
-          encryption: @encryption,
-          access_token: @access_token,
-          content: report,
-          verbose: @verbose
-        }, true)
-        nil
-      rescue ThreadError
-        raise QueueFullError
-      end
 
-      # Flush the current queue
-      def flush
-        close
-        start_queue
-      end
-
-      # Clear the current queue, deleting pending items
-      def clear
-        @queue.clear
-      end
-
-      # Close the transport. No further data can be sent!
-      def close
-        @queue.close
-        @thread.join
-      end
-
-      private
-
-      def start_queue
-        @queue = SizedQueue.new(QUEUE_SIZE)
-        @thread = start_thread(@queue)
-      end
-
-      # TODO(ngauthier@gmail.com) abort on exception?
-      def start_thread(queue)
-        Thread.new do
-          while item = queue.pop
-            post_report(item)
-          end
-        end
-      end
-
-      def post_report(params)
-        https = Net::HTTP.new(params[:host], params[:port])
-        https.use_ssl = params[:encryption] == ENCRYPTION_TLS
+        https = Net::HTTP.new(@host, @port)
+        https.use_ssl = @encryption == ENCRYPTION_TLS
         req = Net::HTTP::Post.new('/api/v0/reports')
-        req['LightStep-Access-Token'] = params[:access_token]
+        req['LightStep-Access-Token'] = @access_token
         req['Content-Type'] = 'application/json'
         req['Connection'] = 'keep-alive'
-        req.body = params[:content].to_json
+        req.body = report.to_json
         res = https.request(req)
 
-        puts res.to_s if params[:verbose] >= 3
+        puts res.to_s if @verbose >= 3
 
-        # TODO(ngauthier@gmail.com): log unknown commands
-        # TODO(ngauthier@gmail.com): log errors from server
+        nil
       end
     end
   end

--- a/lightstep.gemspec
+++ b/lightstep.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'concurrent-ruby', '~> 1.0'
+  spec.add_dependency 'concurrent-ruby-edge', '= 0.2.2'
   spec.add_development_dependency 'rake', '~> 11.3'
   spec.add_development_dependency 'rack', '~> 2.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
**This PR is daisy chained on #27, so that PR should be merged first**

The strategy for merging the buffers is to have a span buffer on the Reporter object, and remove the queueing from the HTTPJSON transport. The HTTPJSON transport will become dumber and simply post http in-band. Then, the Reporter will have a background thread that waits on a channel for a report and sends it to the transport. The Reporter, when flushed, will attempt to send the current span buffer down the channel to the thread in a nonblocking way. If the thread is available, the span buffer will be processed. If the thread is not available, the reporter's flush will not actually flush, it will continue to buffer spans, retrying the non-blocking channel push each time.

In this way, there will only be one span buffer, and then there will be one or zero reports in progress at any given time.

The implementation was done with a mix of `concurrent-ruby` Channels for signaling, and our own tracked threads for fork-safety.

This implementation improves upon the current with:

1. A single buffer (a concurrent array) of spans
1. Only one report can be sent at a time
1. Fork safety (children do not inherit the unflushed spans of parents) - this is automatic now
1. Min and max period timers now actually trigger flushes (fixes situations where max spans is reached before min timer, then min timer fires but no more spans are added, and the reverse where spans are added, max timer is reached, and no more spans are added). This uses go-like timer channels.

We also preserve the following functionality:

1. Synchronous flushes
1. Flush at-exit including all forks with graceful shutdown