### PR TITLE
Set a non-nil runtime guid in submitted reports

### DIFF
--- a/lib/lightstep/reporter.rb
+++ b/lib/lightstep/reporter.rb
@@ -13,7 +13,6 @@ module LightStep
       @transport = transport
 
       start_time = LightStep.micros(Time.now)
-      @guid = LightStep.guid
       @report_start_time = start_time
 
       @runtime = {

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -149,6 +149,8 @@ module LightStep
       raise ConfigurationError, "you must provide an access token or a transport" if transport.nil?
       raise ConfigurationError, "#{transport} is not a LightStep transport class" if !(LightStep::Transport::Base === transport)
 
+      @guid = LightStep.guid
+
       @reporter = LightStep::Reporter.new(
         max_span_records: max_span_records,
         transport: transport,

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -373,4 +373,29 @@ describe LightStep do
       {Name: "dropped_spans", Value: 5}
     ])
   end
+
+  it 'should have a String guid' do
+    tracer = init_test_tracer
+    expect(tracer.guid).to be_a(String)
+  end
+
+  it 'should include the tracer guid in the reported runtime' do
+    result = nil
+    tracer = init_callback_tracer(proc { |obj| result = obj })
+    tracer.start_span('span').finish
+    tracer.flush
+
+    expect(result).to be_a(Hash)
+    expect(result[:runtime][:guid]).to eq(tracer.guid)
+  end
+
+  it 'should include the tracer guid in reported spans' do
+    result = nil
+    tracer = init_callback_tracer(proc { |obj| result = obj })
+    tracer.start_span('span').finish
+    tracer.flush
+
+    expect(result).to be_a(Hash)
+    expect(result[:span_records].first[:runtime_guid]).to eq(tracer.guid)
+  end
 end


### PR DESCRIPTION
`Tracer#guid` was never getting set. This broke in 26ae4f094d632cf816c971614ed8c6d8aa25a87f.

In addition, Reporter's `@guid` ivar was unused, so I removed it.

/cc @ngauthier @bensigelman