### PR TITLE
Simple Report Loop

### DIFF
--- a/benchmark/threading/thread_test.rb
+++ b/benchmark/threading/thread_test.rb
@@ -51,3 +51,4 @@ mutex.unlock
 watchThread.join
 
 puts 'Done!'
+LightStep.flush

--- a/example.rb
+++ b/example.rb
@@ -29,6 +29,6 @@ thread2 = Thread.new do
 end
 [thread1, thread2].each(&:join)
 span.finish
-
+LightStep.flush
 puts 'Done!'
 puts "https://app.lightstep.com/#{access_token}/trace?span_guid=#{span.guid}&at_micros=#{span.start_micros}"

--- a/examples/fork_children/main.rb
+++ b/examples/fork_children/main.rb
@@ -19,6 +19,7 @@ puts 'Starting...'
       sleep(0.0025 * rand(k))
       span.finish
     end
+    LightStep.flush
   end
 
   10.times do
@@ -47,3 +48,5 @@ puts 'Starting...'
 end
 
 puts 'Done!'
+
+LightStep.flush

--- a/lib/lightstep/reporter.rb
+++ b/lib/lightstep/reporter.rb
@@ -1,9 +1,9 @@
-require 'concurrent/channel'
-
 module LightStep
   # Reporter builds up reports of spans and flushes them to a transport
   class Reporter
+    DEFAULT_PERIOD_SECONDS = 3.0
     attr_accessor :max_span_records
+    attr_accessor :period
 
     def initialize(max_span_records:, transport:, guid:, component_name:)
       @max_span_records = max_span_records
@@ -11,6 +11,7 @@ module LightStep
       @dropped_spans = Concurrent::AtomicFixnum.new
       @dropped_span_logs = Concurrent::AtomicFixnum.new
       @transport = transport
+      @period = DEFAULT_PERIOD_SECONDS
 
       start_time = LightStep.micros(Time.now)
       @report_start_time = start_time
@@ -29,8 +30,7 @@ module LightStep
       reset_on_fork
 
       at_exit do
-        @quit_signal << true
-        @thread.join
+        flush
       end
     end
 
@@ -43,11 +43,11 @@ module LightStep
         @dropped_spans.increment
         @dropped_span_logs.increment(dropped[:log_records].size + dropped[:dropped_logs])
       end
-
-      @span_signal << true
     end
 
     def clear
+      reset_on_fork
+
       span_records = @span_records.slice!(0, @span_records.length)
       @dropped_spans.increment(span_records.size)
       @dropped_span_logs.increment(
@@ -58,32 +58,8 @@ module LightStep
     end
 
     def flush
-      @flush_signal << true
-      ~@flush_response_signal
-    end
-
-    private
-    MIN_PERIOD_SECS = 1.5
-    MAX_PERIOD_SECS = 30.0
-
-    # When the process forks, reset the child. All data that was copied will be handled
-    # by the parent. Also, restart the thread since forking killed it
-    def reset_on_fork
-      if @pid != $$
-        @pid = $$
-        @span_signal = Concurrent::Channel.new(buffer: :dropping, capacity: 1)
-        @quit_signal = Concurrent::Channel.new(buffer: :dropping, capacity: 1)
-        @flush_signal = Concurrent::Channel.new
-        @flush_response_signal = Concurrent::Channel.new
-        @span_records.clear
-        @dropped_spans.value = 0
-        @dropped_span_logs.value = 0
-        report_spans
-      end
-    end
-
-    def perform_flush
       reset_on_fork
+
       return if @span_records.empty?
 
       now = LightStep.micros(Time.now)
@@ -123,40 +99,30 @@ module LightStep
       end
     end
 
+    private
+
+    # When the process forks, reset the child. All data that was copied will be handled
+    # by the parent. Also, restart the thread since forking killed it
+    def reset_on_fork
+      if @pid != $$
+        @pid = $$
+        @span_records.clear
+        @dropped_spans.value = 0
+        @dropped_span_logs.value = 0
+        report_spans
+      end
+    end
+
     def report_spans
-      @thread = Thread.new do
+      return if @period <= 0
+      Thread.new do
         begin
           loop do
-            min_reached = false
-            max_reached = false
-            min_timer = Concurrent::Channel.timer(MIN_PERIOD_SECS)
-            max_timer = Concurrent::Channel.timer(MAX_PERIOD_SECS)
-            loop do
-              Concurrent::Channel.select do |s|
-                s.take(@span_signal) do
-                  # we'll check span count below
-                end
-                s.take(min_timer) do
-                  min_reached = true
-                end
-                s.take(max_timer) do
-                  max_reached = true
-                end
-                s.take(@quit_signal) do
-                  perform_flush
-                  Thread.exit
-                end
-                s.take(@flush_signal) do
-                  perform_flush
-                  @flush_response_signal << true
-                end
-              end
-              if max_reached || (min_reached && @span_records.size >= max_span_records / 2)
-                perform_flush
-              end
-            end
+            sleep(@period)
+            flush
           end
         rescue => ex
+          p ex
           # TODO: internally log the exception
         end
       end

--- a/lib/lightstep/reporter.rb
+++ b/lib/lightstep/reporter.rb
@@ -122,7 +122,6 @@ module LightStep
             flush
           end
         rescue => ex
-          p ex
           # TODO: internally log the exception
         end
       end

--- a/lib/lightstep/reporter.rb
+++ b/lib/lightstep/reporter.rb
@@ -28,10 +28,6 @@ module LightStep
       }.freeze
 
       reset_on_fork
-
-      at_exit do
-        flush
-      end
     end
 
     def add_span(span)

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -45,6 +45,8 @@ module LightStep
       @reporter.max_span_records = @max_span_records
     end
 
+    # Set the report flushing period. If set to 0, no flushing will be done, you
+    # must manually call flush.
     def report_period_seconds=(seconds)
       @reporter.period = seconds
     end

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -45,6 +45,10 @@ module LightStep
       @reporter.max_span_records = @max_span_records
     end
 
+    def report_period_seconds=(seconds)
+      @reporter.period = seconds
+    end
+
     # TODO(ngauthier@gmail.com) inherit SpanContext from references
 
     # Starts a new span.

--- a/lightstep.gemspec
+++ b/lightstep.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_dependency 'concurrent-ruby-edge', '= 0.2.2'
   spec.add_development_dependency 'rake', '~> 11.3'
   spec.add_development_dependency 'rack', '~> 2.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Replace all channel and evented report triggering with a simple sleeping loop.

No mutex is needed because the span records buffer is a concurrent array that locks around operations, and we perform a single `slice` at the beginning of flush to atomically remove the records that we will report on.

Forking code was kept to restart the background thread upon fork (and clear spans that would be duplicated in the child).