### PR TITLE
extract SpanContext from span

### DIFF
--- a/example.rb
+++ b/example.rb
@@ -31,4 +31,4 @@ end
 span.finish
 LightStep.flush
 puts 'Done!'
-puts "https://app.lightstep.com/#{access_token}/trace?span_guid=#{span.id}&at_micros=#{span.start_micros}"
+puts "https://app.lightstep.com/#{access_token}/trace?span_guid=#{span.span_context.id}&at_micros=#{span.start_micros}"

--- a/example.rb
+++ b/example.rb
@@ -31,4 +31,4 @@ end
 span.finish
 LightStep.flush
 puts 'Done!'
-puts "https://app.lightstep.com/#{access_token}/trace?span_guid=#{span.guid}&at_micros=#{span.start_micros}"
+puts "https://app.lightstep.com/#{access_token}/trace?span_guid=#{span.id}&at_micros=#{span.start_micros}"

--- a/lib/lightstep/span.rb
+++ b/lib/lightstep/span.rb
@@ -1,5 +1,4 @@
 require 'concurrent'
-require 'forwardable'
 require 'lightstep/span_context'
 
 module LightStep
@@ -7,8 +6,6 @@ module LightStep
   #
   # See http://www.opentracing.io for more information.
   class Span
-    extend Forwardable
-
     # Part of the OpenTracing API
     attr_writer :operation_name
 

--- a/lib/lightstep/span.rb
+++ b/lib/lightstep/span.rb
@@ -16,10 +16,6 @@ module LightStep
     # @private
     attr_reader :start_micros, :end_micros, :baggage, :tags, :operation_name, :span_context
 
-    def_delegator :span_context, :id
-    def_delegator :span_context, :trace_id
-    def_delegator :span_context, :baggage
-
     # Creates a new {Span}
     #
     # @param tracer [Tracer] the tracer that created this span
@@ -72,9 +68,9 @@ module LightStep
     # @param value [String] the value of the baggage item
     def set_baggage_item(key, value)
       @span_context = SpanContext.new(
-        id: id,
-        trace_id: trace_id,
-        baggage: baggage.merge({key => value})
+        id: span_context.id,
+        trace_id: span_context.trace_id,
+        baggage: span_context.baggage.merge({key => value})
       )
       self
     end
@@ -83,8 +79,8 @@ module LightStep
     # @param baggage [Hash] new baggage for the span
     def set_baggage(baggage = {})
       @span_context = SpanContext.new(
-        id: id,
-        trace_id: trace_id,
+        id: span_context.id,
+        trace_id: span_context.trace_id,
         baggage: baggage
       )
     end
@@ -93,7 +89,7 @@ module LightStep
     # @param key [String] the key of the baggage item
     # @return Value of the baggage item
     def get_baggage_item(key)
-      baggage[key]
+      span_context.baggage[key]
     end
 
     # Add a log entry to this span
@@ -137,8 +133,8 @@ module LightStep
     def to_h
       {
         runtime_guid: tracer.guid,
-        span_guid: id,
-        trace_guid: trace_id,
+        span_guid: span_context.id,
+        trace_guid: span_context.trace_id,
         span_name: operation_name,
         attributes: tags.map {|key, value|
           {Key: key.to_s, Value: value}

--- a/lib/lightstep/span_context.rb
+++ b/lib/lightstep/span_context.rb
@@ -1,0 +1,12 @@
+module LightStep
+  # SpanContext holds the data for a span that gets inherited to child spans
+  class SpanContext
+    attr_reader :id, :trace_id, :baggage
+
+    def initialize(id:, trace_id:, baggage: {})
+      @id = id.freeze
+      @trace_id = trace_id.freeze
+      @baggage = baggage.freeze
+    end
+  end
+end

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -63,8 +63,8 @@ module LightStep
       child_of_id = nil
       trace_id = nil
       if Span === child_of
-        child_of_id = child_of.id
-        trace_id = child_of.trace_id
+        child_of_id = child_of.span_context.id
+        trace_id = child_of.span_context.trace_id
       else
         trace_id = LightStep.guid
       end
@@ -182,11 +182,11 @@ module LightStep
     MIN_MAX_SPAN_RECORDS = 1
 
     def inject_to_text_map(span, carrier)
-      carrier[CARRIER_TRACER_STATE_PREFIX + 'spanid'] = span.id
-      carrier[CARRIER_TRACER_STATE_PREFIX + 'traceid'] = span.trace_id unless span.trace_id.nil?
+      carrier[CARRIER_TRACER_STATE_PREFIX + 'spanid'] = span.span_context.id
+      carrier[CARRIER_TRACER_STATE_PREFIX + 'traceid'] = span.span_context.trace_id unless span.span_context.trace_id.nil?
       carrier[CARRIER_TRACER_STATE_PREFIX + 'sampled'] = 'true'
 
-      span.baggage.each do |key, value|
+      span.span_context.baggage.each do |key, value|
         carrier[CARRIER_BAGGAGE_PREFIX + key] = value
       end
     end

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -60,24 +60,30 @@ module LightStep
     # @param tags [Hash] tags for the span
     # @return [Span]
     def start_span(operation_name, child_of: nil, start_time: nil, tags: nil)
-      child_of_guid = nil
-      trace_guid = nil
+      child_of_id = nil
+      trace_id = nil
       if Span === child_of
-        child_of_guid = child_of.guid
-        trace_guid = child_of.trace_guid
+        child_of_id = child_of.id
+        trace_id = child_of.trace_id
       else
-        trace_guid = LightStep.guid
+        trace_id = LightStep.guid
       end
 
-      Span.new(
+      span = Span.new(
         tracer: self,
         operation_name: operation_name,
-        child_of_guid: child_of_guid,
-        trace_guid: trace_guid,
+        child_of_id: child_of_id,
+        trace_id: trace_id,
         start_micros: start_time.nil? ? LightStep.micros(Time.now) : LightStep.micros(start_time),
         tags: tags,
         max_log_records: max_log_records
       )
+
+      if Span === child_of
+        span.set_baggage(child_of.baggage)
+      end
+
+      span
     end
 
     # Inject a span into the given carrier
@@ -176,8 +182,8 @@ module LightStep
     MIN_MAX_SPAN_RECORDS = 1
 
     def inject_to_text_map(span, carrier)
-      carrier[CARRIER_TRACER_STATE_PREFIX + 'spanid'] = span.guid
-      carrier[CARRIER_TRACER_STATE_PREFIX + 'traceid'] = span.trace_guid unless span.trace_guid.nil?
+      carrier[CARRIER_TRACER_STATE_PREFIX + 'spanid'] = span.id
+      carrier[CARRIER_TRACER_STATE_PREFIX + 'traceid'] = span.trace_id unless span.trace_id.nil?
       carrier[CARRIER_TRACER_STATE_PREFIX + 'sampled'] = 'true'
 
       span.baggage.each do |key, value|
@@ -190,16 +196,21 @@ module LightStep
         tracer: self,
         operation_name: operation_name,
         start_micros: LightStep.micros(Time.now),
-        child_of_guid: carrier[CARRIER_TRACER_STATE_PREFIX + 'spanid'],
-        trace_guid: carrier[CARRIER_TRACER_STATE_PREFIX + 'traceid'],
+        child_of_id: carrier[CARRIER_TRACER_STATE_PREFIX + 'spanid'],
+        trace_id: carrier[CARRIER_TRACER_STATE_PREFIX + 'traceid'],
         max_log_records: max_log_records
       )
 
-      carrier.each do |key, value|
-        next unless key.start_with?(CARRIER_BAGGAGE_PREFIX)
-        plain_key = key.to_s[CARRIER_BAGGAGE_PREFIX.length..key.to_s.length]
-        span.set_baggage_item(plain_key, value)
+      baggage = carrier.reduce({}) do |baggage, tuple|
+        key, value = tuple
+        if key.start_with?(CARRIER_BAGGAGE_PREFIX)
+          plain_key = key.to_s[CARRIER_BAGGAGE_PREFIX.length..key.to_s.length]
+          baggage[plain_key] = value
+        end
+        baggage
       end
+      span.set_baggage(baggage)
+
       span
     end
   end

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -48,9 +48,10 @@ describe LightStep do
   it 'should not allow SpanContext modification' do
     tracer = init_test_tracer
     span = tracer.start_span('my_span')
-    expect{span.baggage['foo'] = 'bar'}.to raise_error(RuntimeError)
-    expect{span.id.slice!(0,1)}.to raise_error(RuntimeError)
-    expect{span.trace_id.slice!(0,1)}.to raise_error(RuntimeError)
+    context = span.span_context
+    expect{context.baggage['foo'] = 'bar'}.to raise_error(RuntimeError)
+    expect{context.id.slice!(0,1)}.to raise_error(RuntimeError)
+    expect{context.trace_id.slice!(0,1)}.to raise_error(RuntimeError)
   end
 
   it 'should allow tag-setting at start_span time' do
@@ -91,7 +92,7 @@ describe LightStep do
     tracer = init_test_tracer
     span = tracer.start_span('test_span')
 
-    expect(span.id).to be_an_instance_of String
+    expect(span.span_context.id).to be_an_instance_of String
     span.finish
   end
 
@@ -136,15 +137,15 @@ describe LightStep do
     children2 = (1..4).to_a.map { tracer.start_span('child', child_of: parent2) }
 
     children1.each do |child|
-      expect(child.trace_id).to be_an_instance_of String
-      expect(child.trace_id).to eq(parent1.trace_id)
-      expect(child.trace_id).not_to eq(parent2.trace_id)
+      expect(child.span_context.trace_id).to be_an_instance_of String
+      expect(child.span_context.trace_id).to eq(parent1.span_context.trace_id)
+      expect(child.span_context.trace_id).not_to eq(parent2.span_context.trace_id)
     end
 
     children2.each do |child|
-      expect(child.trace_id).to be_an_instance_of String
-      expect(child.trace_id).to eq(parent2.trace_id)
-      expect(child.trace_id).not_to eq(parent1.trace_id)
+      expect(child.span_context.trace_id).to be_an_instance_of String
+      expect(child.span_context.trace_id).to eq(parent2.span_context.trace_id)
+      expect(child.span_context.trace_id).not_to eq(parent1.span_context.trace_id)
     end
 
     children1.each(&:finish)
@@ -154,7 +155,7 @@ describe LightStep do
 
     (children1.concat children2).each do |child|
       thrift_data = child.to_h
-      expect(thrift_data[:trace_guid]).to eq(child.trace_id)
+      expect(thrift_data[:trace_guid]).to eq(child.span_context.trace_id)
     end
   end
 
@@ -268,14 +269,14 @@ describe LightStep do
 
     carrier = {}
     tracer.inject(span1, LightStep::Tracer::FORMAT_TEXT_MAP, carrier)
-    expect(carrier['ot-tracer-traceid']).to eq(span1.trace_id)
-    expect(carrier['ot-tracer-spanid']).to eq(span1.id)
+    expect(carrier['ot-tracer-traceid']).to eq(span1.span_context.trace_id)
+    expect(carrier['ot-tracer-spanid']).to eq(span1.span_context.id)
     expect(carrier['ot-baggage-footwear']).to eq('cleats')
     expect(carrier['ot-baggage-umbrella']).to eq('golf')
 
     span2 = tracer.extract('test_span_2', LightStep::Tracer::FORMAT_TEXT_MAP, carrier)
-    expect(span2.trace_id).to eq(span1.trace_id)
-    expect(span2.tags[:parent_span_guid]).to eq(span1.id)
+    expect(span2.span_context.trace_id).to eq(span1.span_context.trace_id)
+    expect(span2.tags[:parent_span_guid]).to eq(span1.span_context.id)
     expect(span2.get_baggage_item('footwear')).to eq('cleats')
     expect(span2.get_baggage_item('umbrella')).to eq('golf')
 


### PR DESCRIPTION
* rename Span#guid -> Span#id
* rename Span#trace_guid -> Span#trace_guid
* delegate id, trace_id, baggage to SpanContext
* Freeze SpanContext data to prevent modification
* Copy SpanContext when modifying baggage
* Provide faster Span#set_baggage to bulk set baggage on initialization
* Spans inherit SpanContext fields