### PR TITLE
Rack HTTP Inject + Extract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ test:
 	bundle exec rake spec
 	ruby example.rb
 	ruby examples/fork_children/main.rb
+	ruby examples/rack/inject_extract.rb
 
 benchmark:
 	ruby benchmark/bench.rb

--- a/examples/rack/inject_extract.rb
+++ b/examples/rack/inject_extract.rb
@@ -1,0 +1,66 @@
+require 'bundler/setup'
+require 'lightstep'
+
+require 'rack'
+require 'rack/server'
+
+$token = '{your_access_token}'
+$request_id = 'abc123'
+
+class Router
+  def initialize
+    @tracer = LightStep::Tracer.new(component_name: 'router', access_token: $token)
+  end
+
+  def call(env)
+    span = @tracer.start_span("router_call").set_baggage_item("request-id", $request_id)
+    span.log(event: "router_request", env: env)
+    puts "parent #{span.trace_id}"
+
+    client = Net::HTTP.new("localhost", "9002")
+    req = Net::HTTP::Post.new("/")
+    @tracer.inject(span, LightStep::Tracer::FORMAT_HTTP, req)
+    res = client.request(req)
+
+    span.log(event: "application_response", response: res.to_s)
+    span.finish
+    @tracer.flush
+    puts "----> https://app.lightstep.com/#{$token}/trace?span_guid=#{span.id}&at_micros=#{span.start_micros} <----"
+    [200, {}, [res.body]]
+  end
+end
+
+class App
+  def initialize
+    @tracer = LightStep::Tracer.new(component_name: 'app', access_token: $token)
+  end
+
+  def call(env)
+    span = @tracer.extract("app_call", LightStep::Tracer::FORMAT_HTTP, env)
+    puts "child  #{span.to_h[:trace_guid]}"
+    span.log(event: "application", env: env)
+    sleep 0.05
+    span.finish
+    @tracer.flush
+    [200, {}, ["application"]]
+  end
+end
+
+router_thread = Thread.new do
+  Thread.abort_on_exception = true
+  Rack::Server.start(app: Router.new, Port: 9001)
+end
+
+app_thread = Thread.new do
+  Thread.abort_on_exception = true
+  Rack::Server.start(app: App.new, Port: 9002)
+end
+
+loop do
+  begin
+    p Net::HTTP.get(URI("http://localhost:9001/"))
+    break
+  rescue Errno::ECONNREFUSED
+    sleep 0.05
+  end
+end

--- a/examples/rack/inject_extract.rb
+++ b/examples/rack/inject_extract.rb
@@ -19,7 +19,7 @@ class Router
 
     client = Net::HTTP.new("localhost", "9002")
     req = Net::HTTP::Post.new("/")
-    @tracer.inject(span, LightStep::Tracer::FORMAT_HTTP_HEADERS, req)
+    @tracer.inject(span, LightStep::Tracer::FORMAT_RACK, req)
     res = client.request(req)
 
     span.log(event: "application_response", response: res.to_s)
@@ -36,7 +36,7 @@ class App
   end
 
   def call(env)
-    span = @tracer.extract("app_call", LightStep::Tracer::FORMAT_HTTP_HEADERS, env)
+    span = @tracer.extract("app_call", LightStep::Tracer::FORMAT_RACK, env)
     puts "child  #{span.to_h[:trace_guid]}"
     span.log(event: "application", env: env)
     sleep 0.05

--- a/examples/rack/inject_extract.rb
+++ b/examples/rack/inject_extract.rb
@@ -15,17 +15,17 @@ class Router
   def call(env)
     span = @tracer.start_span("router_call").set_baggage_item("request-id", $request_id)
     span.log(event: "router_request", env: env)
-    puts "parent #{span.trace_id}"
+    puts "parent #{span.span_context.trace_id}"
 
     client = Net::HTTP.new("localhost", "9002")
     req = Net::HTTP::Post.new("/")
-    @tracer.inject(span, LightStep::Tracer::FORMAT_HTTP, req)
+    @tracer.inject(span, LightStep::Tracer::FORMAT_HTTP_HEADERS, req)
     res = client.request(req)
 
     span.log(event: "application_response", response: res.to_s)
     span.finish
     @tracer.flush
-    puts "----> https://app.lightstep.com/#{$token}/trace?span_guid=#{span.id}&at_micros=#{span.start_micros} <----"
+    puts "----> https://app.lightstep.com/#{$token}/trace?span_guid=#{span.span_context.id}&at_micros=#{span.start_micros} <----"
     [200, {}, [res.body]]
   end
 end
@@ -36,7 +36,7 @@ class App
   end
 
   def call(env)
-    span = @tracer.extract("app_call", LightStep::Tracer::FORMAT_HTTP, env)
+    span = @tracer.extract("app_call", LightStep::Tracer::FORMAT_HTTP_HEADERS, env)
     puts "child  #{span.to_h[:trace_guid]}"
     span.log(event: "application", env: env)
     sleep 0.05

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -225,8 +225,7 @@ module LightStep
       carrier[CARRIER_TRACER_STATE_PREFIX + 'sampled'] = 'true'
 
       span.span_context.baggage.each do |key, value|
-        key = key.downcase.gsub("_", "-")
-        if key =~ /[^a-z0-9\-]/
+        if key =~ /[^A-Za-z0-9\-_]/
           # TODO: log the error internally
           next
         end

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -11,7 +11,7 @@ module LightStep
   class Tracer
     FORMAT_TEXT_MAP = 1
     FORMAT_BINARY = 2
-    FORMAT_HTTP = 3
+    FORMAT_HTTP_HEADERS = 3
 
     class Error < LightStep::Error; end
     class ConfigurationError < LightStep::Tracer::Error; end
@@ -97,7 +97,7 @@ module LightStep
         inject_to_text_map(span, carrier)
       when LightStep::Tracer::FORMAT_BINARY
         warn 'Binary inject format not yet implemented'
-      when LightStep::Tracer::FORMAT_HTTP
+      when LightStep::Tracer::FORMAT_HTTP_HEADERS
         inject_to_http_headers(span, carrier)
       else
         warn 'Unknown inject format'
@@ -118,7 +118,7 @@ module LightStep
       when LightStep::Tracer::FORMAT_BINARY
         warn 'Binary join format not yet implemented'
         nil
-      when LightStep::Tracer::FORMAT_HTTP
+      when LightStep::Tracer::FORMAT_HTTP_HEADERS
         extract_from_rack_env(operation_name, carrier)
       else
         warn 'Unknown join format'
@@ -182,8 +182,6 @@ module LightStep
 
     CARRIER_TRACER_STATE_PREFIX = 'ot-tracer-'.freeze
     CARRIER_BAGGAGE_PREFIX = 'ot-baggage-'.freeze
-    CARRIER_RACK_HTTP_TRACER_STATE_PREFIX = "#{CARRIER_TRACER_STATE_PREFIX.gsub("-", "_").upcase}"
-    CARRIER_RACK_HTTP_BAGGAGE_PREFIX = "#{CARRIER_BAGGAGE_PREFIX.gsub("-", "_").upcase}"
 
     DEFAULT_MAX_LOG_RECORDS = 1000
     MIN_MAX_LOG_RECORDS = 1
@@ -224,22 +222,22 @@ module LightStep
     end
 
     def inject_to_http_headers(span, carrier)
-      carrier[CARRIER_RACK_HTTP_TRACER_STATE_PREFIX + 'SPANID'] = span.id
-      carrier[CARRIER_RACK_HTTP_TRACER_STATE_PREFIX + 'TRACEID'] = span.trace_id unless span.trace_id.nil?
-      carrier[CARRIER_RACK_HTTP_TRACER_STATE_PREFIX + 'SAMPLED'] = 'true'
+      carrier[CARRIER_TRACER_STATE_PREFIX + 'spanid'] = span.span_context.id
+      carrier[CARRIER_TRACER_STATE_PREFIX + 'traceid'] = span.span_context.trace_id unless span.span_context.trace_id.nil?
+      carrier[CARRIER_TRACER_STATE_PREFIX + 'sampled'] = 'true'
 
-      span.baggage.each do |key, value|
-        carrier[CARRIER_RACK_HTTP_BAGGAGE_PREFIX + key.gsub("-", "_").upcase.gsub(/[^A-Z0-9_]/, '')] = value
+      span.span_context.baggage.each do |key, value|
+        carrier[CARRIER_BAGGAGE_PREFIX + key.gsub(/[^A-Za-z0-9-]/, '')] = value
       end
     end
 
     def extract_from_rack_env(operation_name, env)
       extract_from_text_map(operation_name, env.reduce({}){|memo, tuple|
         raw_header, value = tuple
-        header = raw_header.gsub(/^HTTP_/, '')
-        if header.start_with?(CARRIER_RACK_HTTP_TRACER_STATE_PREFIX) ||
-           header.start_with?(CARRIER_RACK_HTTP_BAGGAGE_PREFIX)
-          memo[header.gsub("_", "-").downcase] = value
+        header = raw_header.gsub(/^HTTP_/, '').gsub("_","-").downcase
+        if header.start_with?(CARRIER_TRACER_STATE_PREFIX) ||
+           header.start_with?(CARRIER_BAGGAGE_PREFIX)
+          memo[header.downcase] = value
         end
         memo
       })

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -292,21 +292,21 @@ describe LightStep do
     span1.set_baggage_item('unsafe!@#$%$^&header', 'value')
 
     carrier = {}
-    tracer.inject(span1, LightStep::Tracer::FORMAT_HTTP, carrier)
-    expect(carrier['OT_TRACER_TRACEID']).to eq(span1.trace_id)
-    expect(carrier['OT_TRACER_SPANID']).to eq(span1.id)
-    expect(carrier['OT_BAGGAGE_FOOTWEAR']).to eq('cleats')
-    expect(carrier['OT_BAGGAGE_UMBRELLA']).to eq('golf')
-    expect(carrier['OT_BAGGAGE_UNSAFEHEADER']).to eq('value')
+    tracer.inject(span1, LightStep::Tracer::FORMAT_HTTP_HEADERS, carrier)
+    expect(carrier['ot-tracer-traceid']).to eq(span1.span_context.trace_id)
+    expect(carrier['ot-tracer-spanid']).to eq(span1.span_context.id)
+    expect(carrier['ot-baggage-footwear']).to eq('cleats')
+    expect(carrier['ot-baggage-umbrella']).to eq('golf')
+    expect(carrier['ot-baggage-unsafeheader']).to eq('value')
 
-    span2 = tracer.extract('test_span_2', LightStep::Tracer::FORMAT_HTTP, carrier)
-    expect(span2.trace_id).to eq(span1.trace_id)
-    expect(span2.tags[:parent_span_guid]).to eq(span1.id)
+    span2 = tracer.extract('test_span_2', LightStep::Tracer::FORMAT_HTTP_HEADERS, carrier)
+    expect(span2.span_context.trace_id).to eq(span1.span_context.trace_id)
+    expect(span2.tags[:parent_span_guid]).to eq(span1.span_context.id)
     expect(span2.get_baggage_item('footwear')).to eq('cleats')
     expect(span2.get_baggage_item('umbrella')).to eq('golf')
 
-    span3 = tracer.extract('test_span_3', LightStep::Tracer::FORMAT_HTTP, {'HTTP_OT_TRACER_TRACEID' => 'abc123'})
-    expect(span3.trace_id).to eq('abc123')
+    span3 = tracer.extract('test_span_3', LightStep::Tracer::FORMAT_HTTP_HEADERS, {'HTTP_OT_TRACER_TRACEID' => 'abc123'})
+    expect(span3.span_context.trace_id).to eq('abc123')
 
     span1.finish
     span2.finish

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -290,6 +290,7 @@ describe LightStep do
     span1.set_baggage_item('footwear', 'cleats')
     span1.set_baggage_item('umbrella', 'golf')
     span1.set_baggage_item('unsafe!@#$%$^&header', 'value')
+    span1.set_baggage_item('CASE-Sensitivity_Underscores', 'value')
 
     carrier = {}
     tracer.inject(span1, LightStep::Tracer::FORMAT_HTTP_HEADERS, carrier)
@@ -297,13 +298,17 @@ describe LightStep do
     expect(carrier['ot-tracer-spanid']).to eq(span1.span_context.id)
     expect(carrier['ot-baggage-footwear']).to eq('cleats')
     expect(carrier['ot-baggage-umbrella']).to eq('golf')
-    expect(carrier['ot-baggage-unsafeheader']).to eq('value')
+    expect(carrier['ot-baggage-unsafeheader']).to be_nil
+    expect(carrier['ot-baggage-case-sensitivity-underscores']).to eq('value')
 
     span2 = tracer.extract('test_span_2', LightStep::Tracer::FORMAT_HTTP_HEADERS, carrier)
     expect(span2.span_context.trace_id).to eq(span1.span_context.trace_id)
     expect(span2.tags[:parent_span_guid]).to eq(span1.span_context.id)
     expect(span2.get_baggage_item('footwear')).to eq('cleats')
     expect(span2.get_baggage_item('umbrella')).to eq('golf')
+    expect(span2.get_baggage_item('unsafe!@#$%$^&header')).to be_nil
+    expect(span2.get_baggage_item('unsafeheader')).to be_nil
+    expect(span2.get_baggage_item('case-sensitivity-underscores')).to eq('value')
 
     span3 = tracer.extract('test_span_3', LightStep::Tracer::FORMAT_HTTP_HEADERS, {'HTTP_OT_TRACER_TRACEID' => 'abc123'})
     expect(span3.span_context.trace_id).to eq('abc123')

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -299,7 +299,7 @@ describe LightStep do
     expect(carrier['ot-baggage-footwear']).to eq('cleats')
     expect(carrier['ot-baggage-umbrella']).to eq('golf')
     expect(carrier['ot-baggage-unsafeheader']).to be_nil
-    expect(carrier['ot-baggage-case-sensitivity-underscores']).to eq('value')
+    expect(carrier['ot-baggage-CASE-Sensitivity_Underscores']).to eq('value')
 
     carrier = carrier.reduce({}) do |memo, tuple|
       key, value = tuple


### PR DESCRIPTION
# Daisy chained on #35, that should be merged first

* Adds HTTP format for inject and extract
* The carrier will be a hash whose keys are /[A-Z0-9_]/ equivalents of the text map format
* For ruby Net::HTTP requests, the request object can be used as a carrier
* For extracting rack requests, the env can be used as a carrier (the rack-added HTTP_ prefix gets removed if present)
* Spec provided to unit test inject/extract
* Example provided with two rack applications where one requests to the other and data is propagated across them. Screenshot of trace below.

![screenshot_2016-11-10_10-31-26](https://cloud.githubusercontent.com/assets/13654/20182784/f94cb6ca-a730-11e6-836e-8e0675c58f35.png)
