### PR TITLE
Don't reseed the PRNG on every LightStep.guid call

### DIFF
--- a/lib/lightstep.rb
+++ b/lib/lightstep.rb
@@ -28,7 +28,7 @@ module LightStep
   def self.guid
     @_rng ||= Random.new
     # Re-seed the PRNG on a PID change
-    if @_lastpid ||= $$
+    if @_lastpid != $$
       @_lastpid = $$
       @_rng = Random.new
     end

--- a/lib/lightstep.rb
+++ b/lib/lightstep.rb
@@ -26,9 +26,8 @@ module LightStep
   # Returns a random guid. Note: this intentionally does not use SecureRandom,
   # which is slower and cryptographically secure randomness is not required here.
   def self.guid
-    # Re-seed the PRNG on a PID change
-    if @_lastpid != $$
-      @_lastpid = $$
+    if @_lastpid != Process.pid
+      @_lastpid = Process.pid
       @_rng = Random.new
     end
     @_rng.bytes(8).unpack('H*')[0]

--- a/lib/lightstep.rb
+++ b/lib/lightstep.rb
@@ -26,7 +26,6 @@ module LightStep
   # Returns a random guid. Note: this intentionally does not use SecureRandom,
   # which is slower and cryptographically secure randomness is not required here.
   def self.guid
-    @_rng ||= Random.new
     # Re-seed the PRNG on a PID change
     if @_lastpid != $$
       @_lastpid = $$

--- a/lib/lightstep.rb
+++ b/lib/lightstep.rb
@@ -26,7 +26,7 @@ module LightStep
   # Returns a random guid. Note: this intentionally does not use SecureRandom,
   # which is slower and cryptographically secure randomness is not required here.
   def self.guid
-    if @_lastpid != Process.pid
+    unless @_lastpid == Process.pid
       @_lastpid = Process.pid
       @_rng = Random.new
     end


### PR DESCRIPTION
`@_lastpid ||= $$` will evaluate to true every time. I also cleaned up this code slightly while I was in the area.

/cc @bhs https://github.com/lightstep/lightstep-tracer-ruby/pull/41#discussion_r92264877