### PR TITLE
Ensure span names are always strings

### DIFF
--- a/lib/lightstep/span.rb
+++ b/lib/lightstep/span.rb
@@ -16,7 +16,8 @@ module LightStep
     # Creates a new {Span}
     #
     # @param tracer [Tracer] the tracer that created this span
-    # @param operation_name [String] the operation name of this span
+    # @param operation_name [String] the operation name of this span. If it's
+    # not a String it will be encoded with to_s.
     # @param child_of_guid [String] the guid of the span this span is a child of
     # @param trace_guid [String] the guid of this span's trace
     # @param start_micros [Numeric] start time of the span in microseconds
@@ -37,7 +38,7 @@ module LightStep
       @max_log_records = max_log_records
 
       @tracer = tracer
-      self.operation_name = operation_name
+      self.operation_name = operation_name.to_s
       self.start_micros = start_micros
       @span_context = SpanContext.new(id: LightStep.guid, trace_id: trace_id)
       set_tag(:parent_span_guid, child_of_id) if !child_of_id.nil?

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -487,4 +487,15 @@ describe LightStep do
     expect(result).to be_a(Hash)
     expect(result[:span_records].first[:runtime_guid]).to eq(tracer.guid)
   end
+
+  it 'should convert span names to strings' do
+    result = nil
+    tracer = init_callback_tracer(proc { |obj| result = obj })
+    tracer.start_span(5).finish
+    tracer.start_span([:foo]).finish
+    tracer.flush
+    records = result[:span_records]
+    expect(records[0][:span_name]).to eq("5")
+    expect(records[1][:span_name]).to eq("[:foo]")
+  end
 end


### PR DESCRIPTION
The collector will reject any report that contains a non-string span name, so now we convert span names to strings via `#to_s`. This matches what we do with tag values.