### PR TITLE
Fix dropped span counts

### DIFF
--- a/lib/lightstep/reporter.rb
+++ b/lib/lightstep/reporter.rb
@@ -78,10 +78,11 @@ module LightStep
         oldest_micros: @report_start_time,
         youngest_micros: now,
         span_records: span_records,
-        counters: [
-          {Name: "dropped_logs",  Value: dropped_logs},
-          {Name: "dropped_spans", Value: dropped_spans},
-        ]
+        internal_metrics: {
+	  counts: [
+	    {name: "spans.dropped", int64_value: dropped_spans},
+	  ]
+        }
       }
 
       @report_start_time = now

--- a/lib/lightstep/span.rb
+++ b/lib/lightstep/span.rb
@@ -102,7 +102,7 @@ module LightStep
         record[:payload_json] = JSON.generate(fields, max_nesting: 8)
       rescue
         # TODO: failure to encode a payload as JSON should be recorded in the
-        # internal library logs, with catioun not flooding the internal logs.
+        # internal library logs, being careful not to flood them.
       end
 
       log_records.push(record)


### PR DESCRIPTION
The dropped spans had the incorrect location in the nested structs AND the wrong name. Admittedly this is confusing due to some protocol evolution.

Old: https://github.com/lightstep/lightstep-tracer-go/blob/master/lightstep_thrift/ttypes.go#L2656

New: https://github.com/lightstep/lightstep-tracer-go/blob/master/lightstep_thrift/ttypes.go#L2658

Hand-verified that this works.