### PR TITLE
Fix baggage not being inherited form parent span

### DIFF
--- a/lib/lightstep/span.rb
+++ b/lib/lightstep/span.rb
@@ -11,7 +11,7 @@ module LightStep
 
     # Internal use only
     # @private
-    attr_reader :start_micros, :end_micros, :baggage, :tags, :operation_name, :span_context
+    attr_reader :start_micros, :end_micros, :tags, :operation_name, :span_context
 
     # Creates a new {Span}
     #
@@ -76,6 +76,11 @@ module LightStep
         trace_id: span_context.trace_id,
         baggage: baggage
       )
+    end
+
+    # Returns the baggage associated with the span
+    def baggage
+      @span_context.nil? ? {} : @span_context.baggage
     end
 
     # Get a baggage item

--- a/lib/lightstep/span.rb
+++ b/lib/lightstep/span.rb
@@ -78,11 +78,6 @@ module LightStep
       )
     end
 
-    # Returns the baggage associated with the span
-    def baggage
-      @span_context.nil? ? {} : @span_context.baggage
-    end
-
     # Get a baggage item
     # @param key [String] the key of the baggage item
     # @return Value of the baggage item

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -82,7 +82,7 @@ module LightStep
       )
 
       if Span === child_of
-        span.set_baggage(child_of.baggage)
+        span.set_baggage(child_of.span_context.baggage)
       end
 
       span

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -24,6 +24,14 @@ describe LightStep do
     span.finish
   end
 
+  it 'should inherit baggage from parent spans' do
+    tracer = init_test_tracer
+    parent_span = tracer.start_span('parent_span')
+    parent_span.set_baggage(test: 'value')
+    child_span = tracer.start_span('child_span', child_of: parent_span)
+    expect(child_span.span_context.baggage).to eq(parent_span.span_context.baggage)
+  end
+
   it 'should allow operation_name updates' do
     tracer = init_test_tracer
     span = tracer.start_span('original')


### PR DESCRIPTION
There was an `attr_reader` on `Span` that was being used although it was never set. I believe the intention is for `Span#baggage` to return the baggage from its `SpanContext`. Without this, `Tracer#inject` will crash when a child span is used, since `span.span_context.baggage` will return `nil`.

The cause of this is the default value for the method param https://github.com/lightstep/lightstep-tracer-ruby/blob/master/lib/lightstep/span.rb#L73. When `Span#set_baggage` gets called with the `nil` attribute @ https://github.com/lightstep/lightstep-tracer-ruby/blob/master/lib/lightstep/tracer.rb#L85, the default value is overridden with `nil`.

This should address the issue; please let me know if I misunderstood anything or if any changes need to be made.