### PR TITLE
Prepend Tracer:: to ConfigurationError to fix namespacing issue

### DIFF
--- a/lib/lightstep/transport/http_json.rb
+++ b/lib/lightstep/transport/http_json.rb
@@ -30,8 +30,8 @@ module LightStep
         @verbose = verbose
         @encryption = encryption
 
-        raise ConfigurationError, "access_token must be a string" unless String === access_token
-        raise ConfigurationError, "access_token cannot be blank"  if access_token.empty?
+        raise Tracer::ConfigurationError, "access_token must be a string" unless String === access_token
+        raise Tracer::ConfigurationError, "access_token cannot be blank"  if access_token.empty?
         @access_token = access_token
       end
 


### PR DESCRIPTION
**Problem:**
When an empty access token is passed to http_json.rb, it attempts to raise a ConfigurationError, but instead of the ConfigurationError exception, you get 
`http_json.rb:33:in 'initialize': uninitialized constant LightStep::Transport::HTTPJSON::ConfigurationError (NameError)`

**Reason:**
This is because HTTPJSON is name spaced under `LightStep::Transport` and not `LightStep::Tracer`

**Solution:**
Prepend `Tracer::` to `ConfigurationError` so that Ruby knows where to look for the ConfigurationError class

After the fix, you get
`http_json.rb:33:in 'initialize': access_token must be a string (LightStep::Tracer::ConfigurationError)` as intended. 
