### PR TITLE
Check for span_id and trace_id before doing an extract

### DIFF
--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -225,7 +225,7 @@ module LightStep
         end
         span.set_baggage(baggage)
       else
-        span = start_span(operation_name: operation_name)
+        span = start_span(operation_name)
       end
 
       span

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -205,28 +205,28 @@ module LightStep
     def extract_from_text_map(operation_name, carrier)
       # If the carrier does not have both the span_id and trace_id key
       # skip the processing and just return a normal span
-      if carrier.has_key?(CARRIER_SPAN_ID) && carrier.has_key?(CARRIER_TRACE_ID)
-        span = Span.new(
-          tracer: self,
-          operation_name: operation_name,
-          start_micros: LightStep.micros(Time.now),
-          child_of_id: carrier[CARRIER_SPAN_ID],
-          trace_id: carrier[CARRIER_TRACE_ID],
-          max_log_records: max_log_records
-        )
-
-        baggage = carrier.reduce({}) do |baggage, tuple|
-          key, value = tuple
-          if key.start_with?(CARRIER_BAGGAGE_PREFIX)
-            plain_key = key.to_s[CARRIER_BAGGAGE_PREFIX.length..key.to_s.length]
-            baggage[plain_key] = value
-          end
-          baggage
-        end
-        span.set_baggage(baggage)
-      else
-        span = start_span(operation_name)
+      if !carrier.has_key?(CARRIER_SPAN_ID) || !carrier.has_key?(CARRIER_TRACE_ID)
+        return start_span(operation_name)
       end
+
+      span = Span.new(
+        tracer: self,
+        operation_name: operation_name,
+        start_micros: LightStep.micros(Time.now),
+        child_of_id: carrier[CARRIER_SPAN_ID],
+        trace_id: carrier[CARRIER_TRACE_ID],
+        max_log_records: max_log_records
+      )
+
+      baggage = carrier.reduce({}) do |baggage, tuple|
+        key, value = tuple
+        if key.start_with?(CARRIER_BAGGAGE_PREFIX)
+          plain_key = key.to_s[CARRIER_BAGGAGE_PREFIX.length..key.to_s.length]
+          baggage[plain_key] = value
+        end
+        baggage
+      end
+      span.set_baggage(baggage)
 
       span
     end


### PR DESCRIPTION
**Problem:**
When extract is called, the current code does not check to see if the span_id or trace_id exists, it just proceeds to set it to whatever value that is in the carrier. That in turns causes the default trace_id to be overwritten and causes problems during trace assembly. 

**Proposed solution:**
Check if both the span_id and trace_id exist in the carrier, if they do, extract it and set the baggage. If they don't, just create a normal span and return that.

**Alternative solution 1:**
Check if trace_id is nil in `Span.new` and assign a trace_id if it is. 