### PR TITLE
Modernize per the main OpenTracing spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or install it yourself as:
 
     # Create a child span (and add some artificial delays to illustrate the timing)
     sleep(0.1)
-    child = LightStep.start_span('my_child', child_of: span)
+    child = LightStep.start_span('my_child', child_of: span.span_context)
     sleep(0.2)
     child.finish
     sleep(0.1)

--- a/benchmark/bench.rb
+++ b/benchmark/bench.rb
@@ -53,7 +53,7 @@ Benchmark.bm(32) do |x|
     span = tracer.start_span('my_span')
     for i in 0..10_000
       carrier = {}
-      tracer.inject(span, LightStep::Tracer::FORMAT_TEXT_MAP, carrier)
+      tracer.inject(span.span_context, LightStep::Tracer::FORMAT_TEXT_MAP, carrier)
      end
     span.finish
   end

--- a/example.rb
+++ b/example.rb
@@ -20,7 +20,7 @@ end
 thread2 = Thread.new do
   current = 1
   for i in 1..16
-    child = LightStep.start_span('my_child', child_of: span)
+    child = LightStep.start_span('my_child', child_of: span.span_context)
     sleep(0.1)
     current *= 2
     child.log(event: "2^#{i}", result: current)

--- a/examples/fork_children/main.rb
+++ b/examples/fork_children/main.rb
@@ -13,14 +13,14 @@ puts 'Starting...'
 (1..20).each do |k|
   puts "Explicit reset iteration #{k}..."
 
-  # pid = Process.fork do
-  #   10.times do
-  #     span = LightStep.start_span("my_forked_span-#{Process.pid}")
-  #     sleep(0.0025 * rand(k))
-  #     span.finish
-  #   end
-  #   LightStep.flush
-  # end
+  pid = Process.fork do
+    10.times do
+      span = LightStep.start_span("my_forked_span-#{Process.pid}")
+      sleep(0.0025 * rand(k))
+      span.finish
+    end
+    LightStep.flush
+  end
 
   3.times do
     span = LightStep.start_span("my_process_span-#{Process.pid}")
@@ -30,23 +30,23 @@ puts 'Starting...'
     span.finish
   end
 
-  # # Make sure redundant enable calls don't cause problems
-  # # NOTE: disabling discards the buffer by default, so all spans
-  # # get cleared here except the final toggle span
-  # 10.times do
-  #   LightStep.disable
-  #   LightStep.enable
-  #   LightStep.disable
-  #   LightStep.disable
-  #   LightStep.enable
-  #   LightStep.enable
-  #   span = LightStep.start_span("my_toggle_span-#{Process.pid}")
-  #   sleep(0.0025 * rand(k))
-  #   span.finish
-  # end
+  # Make sure redundant enable calls don't cause problems
+  # NOTE: disabling discards the buffer by default, so all spans
+  # get cleared here except the final toggle span
+  10.times do
+    LightStep.disable
+    LightStep.enable
+    LightStep.disable
+    LightStep.disable
+    LightStep.enable
+    LightStep.enable
+    span = LightStep.start_span("my_toggle_span-#{Process.pid}")
+    sleep(0.0025 * rand(k))
+    span.finish
+  end
 
-  # puts "Parent, pid #{Process.pid}, waiting on child pid #{pid}"
-  # Process.wait(pid)
+  puts "Parent, pid #{Process.pid}, waiting on child pid #{pid}"
+  Process.wait(pid)
 end
 
 puts 'Done!'

--- a/examples/rack/inject_extract.rb
+++ b/examples/rack/inject_extract.rb
@@ -19,7 +19,7 @@ class Router
 
     client = Net::HTTP.new("localhost", "9002")
     req = Net::HTTP::Post.new("/")
-    @tracer.inject(span, LightStep::Tracer::FORMAT_RACK, req)
+    @tracer.inject(span.span_context, LightStep::Tracer::FORMAT_RACK, req)
     res = client.request(req)
 
     span.log(event: "application_response", response: res.to_s)
@@ -36,7 +36,8 @@ class App
   end
 
   def call(env)
-    span = @tracer.extract("app_call", LightStep::Tracer::FORMAT_RACK, env)
+    wire_ctx = @tracer.extract(LightStep::Tracer::FORMAT_RACK, env)
+    span = @tracer.start_span("app_call", child_of: wire_ctx)
     puts "child  #{span.to_h[:trace_guid]}"
     span.log(event: "application", env: env)
     sleep 0.05

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -53,72 +53,61 @@ module LightStep
       @reporter.period = seconds
     end
 
-    # TODO(ngauthier@gmail.com) inherit SpanContext from references
+    # TODO(bhs): Support FollowsFrom and multiple references
 
     # Starts a new span.
-    # @param operation_name [String] the operation name for the Span
-    # @param child_of [Span] Span to inherit from
+    #
+    # @param operation_name [String] The operation name for the Span
+    # @param child_of [SpanContext] SpanContext that acts as a parent to
+    #        the newly-started Span. If a Span instance is provided, its
+    #        .span_context is automatically substituted.
     # @param start_time [Time] When the Span started, if not now
-    # @param tags [Hash] tags for the span
+    # @param tags [Hash] Tags to assign to the Span at start time
     # @return [Span]
     def start_span(operation_name, child_of: nil, start_time: nil, tags: nil)
-      child_of_id = nil
-      trace_id = nil
-      if Span === child_of
-        child_of_id = child_of.span_context.id
-        trace_id = child_of.span_context.trace_id
-      else
-        trace_id = LightStep.guid
-      end
-
       span = Span.new(
         tracer: self,
         operation_name: operation_name,
-        child_of_id: child_of_id,
-        trace_id: trace_id,
+        child_of: child_of,
         start_micros: start_time.nil? ? LightStep.micros(Time.now) : LightStep.micros(start_time),
         tags: tags,
-        max_log_records: max_log_records
+        max_log_records: max_log_records,
       )
-
-      if Span === child_of
-        span.set_baggage(child_of.span_context.baggage)
-      end
 
       span
     end
 
-    # Inject a span into the given carrier
-    # @param span [Span]
+    # Inject a SpanContext into the given carrier
+    #
+    # @param spancontext [SpanContext]
     # @param format [LightStep::Tracer::FORMAT_TEXT_MAP, LightStep::Tracer::FORMAT_BINARY]
     # @param carrier [Hash]
-    def inject(span, format, carrier)
+    def inject(span_context, format, carrier)
       case format
       when LightStep::Tracer::FORMAT_TEXT_MAP
-        inject_to_text_map(span, carrier)
+        inject_to_text_map(span_context, carrier)
       when LightStep::Tracer::FORMAT_BINARY
         warn 'Binary inject format not yet implemented'
       when LightStep::Tracer::FORMAT_RACK
-        inject_to_rack(span, carrier)
+        inject_to_rack(span_context, carrier)
       else
         warn 'Unknown inject format'
       end
     end
 
-    # Extract a span from a carrier
-    # @param operation_name [String]
+    # Extract a SpanContext from a carrier
     # @param format [LightStep::Tracer::FORMAT_TEXT_MAP, LightStep::Tracer::FORMAT_BINARY]
     # @param carrier [Hash]
-    # @return [Span]
-    def extract(operation_name, format, carrier)
+    # @return [SpanContext] the extracted SpanContext or nil if none could be found
+    def extract(format, carrier)
       case format
       when LightStep::Tracer::FORMAT_TEXT_MAP
-        extract_from_text_map(operation_name, carrier)
+        extract_from_text_map(carrier)
       when LightStep::Tracer::FORMAT_BINARY
         warn 'Binary join format not yet implemented'
         nil
       when LightStep::Tracer::FORMAT_RACK
-        extract_from_rack(operation_name, carrier)
+        extract_from_rack(carrier)
       else
         warn 'Unknown join format'
         nil
@@ -192,31 +181,22 @@ module LightStep
     DEFAULT_MAX_SPAN_RECORDS = 1000
     MIN_MAX_SPAN_RECORDS = 1
 
-    def inject_to_text_map(span, carrier)
-      carrier[CARRIER_SPAN_ID] = span.span_context.id
-      carrier[CARRIER_TRACE_ID] = span.span_context.trace_id unless span.span_context.trace_id.nil?
+    def inject_to_text_map(span_context, carrier)
+      carrier[CARRIER_SPAN_ID] = span_context.id
+      carrier[CARRIER_TRACE_ID] = span_context.trace_id unless span_context.trace_id.nil?
       carrier[CARRIER_SAMPLED] = 'true'
 
-      span.span_context.baggage.each do |key, value|
+      span_context.baggage.each do |key, value|
         carrier[CARRIER_BAGGAGE_PREFIX + key] = value
       end
     end
 
-    def extract_from_text_map(operation_name, carrier)
+    def extract_from_text_map(carrier)
       # If the carrier does not have both the span_id and trace_id key
       # skip the processing and just return a normal span
       if !carrier.has_key?(CARRIER_SPAN_ID) || !carrier.has_key?(CARRIER_TRACE_ID)
-        return start_span(operation_name)
+        return nil
       end
-
-      span = Span.new(
-        tracer: self,
-        operation_name: operation_name,
-        start_micros: LightStep.micros(Time.now),
-        child_of_id: carrier[CARRIER_SPAN_ID],
-        trace_id: carrier[CARRIER_TRACE_ID],
-        max_log_records: max_log_records
-      )
 
       baggage = carrier.reduce({}) do |baggage, tuple|
         key, value = tuple
@@ -226,17 +206,20 @@ module LightStep
         end
         baggage
       end
-      span.set_baggage(baggage)
-
-      span
+      span_context = SpanContext.new(
+        id: carrier[CARRIER_SPAN_ID],
+        trace_id: carrier[CARRIER_TRACE_ID],
+        baggage: baggage,
+      )
+      span_context
     end
 
-    def inject_to_rack(span, carrier)
-      carrier[CARRIER_SPAN_ID] = span.span_context.id
-      carrier[CARRIER_TRACE_ID] = span.span_context.trace_id unless span.span_context.trace_id.nil?
+    def inject_to_rack(span_context, carrier)
+      carrier[CARRIER_SPAN_ID] = span_context.id
+      carrier[CARRIER_TRACE_ID] = span_context.trace_id unless span_context.trace_id.nil?
       carrier[CARRIER_SAMPLED] = 'true'
 
-      span.span_context.baggage.each do |key, value|
+      span_context.baggage.each do |key, value|
         if key =~ /[^A-Za-z0-9\-_]/
           # TODO: log the error internally
           next
@@ -245,8 +228,8 @@ module LightStep
       end
     end
 
-    def extract_from_rack(operation_name, env)
-      extract_from_text_map(operation_name, env.reduce({}){|memo, tuple|
+    def extract_from_rack(env)
+      extract_from_text_map(env.reduce({}){|memo, tuple|
         raw_header, value = tuple
         header = raw_header.gsub(/^HTTP_/, '').gsub("_", "-").downcase
 

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -65,7 +65,7 @@ module LightStep
     # @param tags [Hash] Tags to assign to the Span at start time
     # @return [Span]
     def start_span(operation_name, child_of: nil, start_time: nil, tags: nil)
-      span = Span.new(
+      Span.new(
         tracer: self,
         operation_name: operation_name,
         child_of: child_of,
@@ -73,8 +73,6 @@ module LightStep
         tags: tags,
         max_log_records: max_log_records,
       )
-
-      span
     end
 
     # Inject a SpanContext into the given carrier
@@ -83,6 +81,7 @@ module LightStep
     # @param format [LightStep::Tracer::FORMAT_TEXT_MAP, LightStep::Tracer::FORMAT_BINARY]
     # @param carrier [Hash]
     def inject(span_context, format, carrier)
+      child_of = child_of.span_context if (Span === child_of)
       case format
       when LightStep::Tracer::FORMAT_TEXT_MAP
         inject_to_text_map(span_context, carrier)
@@ -206,12 +205,11 @@ module LightStep
         end
         baggage
       end
-      span_context = SpanContext.new(
+      SpanContext.new(
         id: carrier[CARRIER_SPAN_ID],
         trace_id: carrier[CARRIER_TRACE_ID],
         baggage: baggage,
       )
-      span_context
     end
 
     def inject_to_rack(span_context, carrier)


### PR DESCRIPTION
Note that the "OpenTracing spec" here is
https://github.com/opentracing/specification/blob/master/specification.md
rather than github.com/opentracing/opentracing-ruby (which does not
reflect Summer 2016 changes to Inject/Extract).

The idea here is to have the small number of LightStep API users vet
these changes before they're proposed in opentracing-ruby.

Given the dynamic nature of Ruby's type system, the ordering of
LightStep and OpenTracing API changes is formally unimportant.