### PR TITLE
Reference the OpenTracing copy of FORMAT codes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in opentracing.gemspec
+# Specify your gem's dependencies in lightstep.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+# Specify your gem's dependencies in opentracing.gemspec
 gemspec

--- a/lib/lightstep/version.rb
+++ b/lib/lightstep/version.rb
@@ -1,3 +1,3 @@
 module LightStep
-  VERSION = '0.11.2'.freeze
+  VERSION = '0.12.0'.freeze
 end

--- a/lightstep.gemspec
+++ b/lightstep.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_dependency 'opentracing', '~> 0.2'
+  spec.add_dependency 'opentracing', '~> 0.3'
   spec.add_development_dependency 'rake', '~> 11.3'
   spec.add_development_dependency 'rack', '~> 2.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -304,13 +304,13 @@ describe LightStep do
     span1.set_baggage_item('umbrella', 'golf')
 
     carrier = {}
-    tracer.inject(span1.span_context, LightStep::Tracer::FORMAT_TEXT_MAP, carrier)
+    tracer.inject(span1.span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
     expect(carrier['ot-tracer-traceid']).to eq(span1.span_context.trace_id)
     expect(carrier['ot-tracer-spanid']).to eq(span1.span_context.id)
     expect(carrier['ot-baggage-footwear']).to eq('cleats')
     expect(carrier['ot-baggage-umbrella']).to eq('golf')
 
-    span_ctx = tracer.extract(LightStep::Tracer::FORMAT_TEXT_MAP, carrier)
+    span_ctx = tracer.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
     expect(span_ctx.trace_id).to eq(span1.span_context.trace_id)
     expect(span_ctx.id).to eq(span1.span_context.id)
     expect(span_ctx.baggage['footwear']).to eq('cleats')
@@ -328,7 +328,7 @@ describe LightStep do
     span1.set_baggage_item('CASE-Sensitivity_Underscores', 'value')
 
     carrier = {}
-    tracer.inject(span1.span_context, LightStep::Tracer::FORMAT_RACK, carrier)
+    tracer.inject(span1.span_context, OpenTracing::FORMAT_RACK, carrier)
     expect(carrier['ot-tracer-traceid']).to eq(span1.span_context.trace_id)
     expect(carrier['ot-tracer-spanid']).to eq(span1.span_context.id)
     expect(carrier['ot-baggage-footwear']).to eq('cleats')
@@ -342,7 +342,7 @@ describe LightStep do
       memo
     end
 
-    span_ctx = tracer.extract(LightStep::Tracer::FORMAT_RACK, carrier)
+    span_ctx = tracer.extract(OpenTracing::FORMAT_RACK, carrier)
     expect(span_ctx.trace_id).to eq(span1.span_context.trace_id)
     expect(span_ctx.id).to eq(span1.span_context.id)
     expect(span_ctx.baggage['footwear']).to eq('cleats')
@@ -352,13 +352,13 @@ describe LightStep do
     expect(span_ctx.baggage['case-sensitivity-underscores']).to eq('value')
 
     # We need both a TRACEID and SPANID.
-    span_ctx = tracer.extract(LightStep::Tracer::FORMAT_RACK, {'HTTP_OT_TRACER_TRACEID' => 'abc123'})
+    span_ctx = tracer.extract(OpenTracing::FORMAT_RACK, {'HTTP_OT_TRACER_TRACEID' => 'abc123'})
     expect(span_ctx).to be_nil
-    span_ctx = tracer.extract(LightStep::Tracer::FORMAT_RACK, {'HTTP_OT_TRACER_SPANID' => 'abc123'})
+    span_ctx = tracer.extract(OpenTracing::FORMAT_RACK, {'HTTP_OT_TRACER_SPANID' => 'abc123'})
     expect(span_ctx).to be_nil
 
     # We need both a TRACEID and SPANID; this has both so it should work.
-    span_ctx = tracer.extract(LightStep::Tracer::FORMAT_RACK, {'HTTP_OT_TRACER_SPANID' => 'abc123', 'HTTP_OT_TRACER_TRACEID' => 'bcd234'})
+    span_ctx = tracer.extract(OpenTracing::FORMAT_RACK, {'HTTP_OT_TRACER_SPANID' => 'abc123', 'HTTP_OT_TRACER_TRACEID' => 'bcd234'})
     expect(span_ctx.id).to eq('abc123')
     expect(span_ctx.trace_id).to eq('bcd234')
 


### PR DESCRIPTION
This is technically a breaking change since symbols were removed; bumping version accordingly.