### PR TITLE
LS-495 Fixes transport being overwritten

### DIFF
--- a/benchmark/threading/thread_test.rb
+++ b/benchmark/threading/thread_test.rb
@@ -16,7 +16,7 @@ watchThread = Thread.new do
     sleep(0.5)
     mutex.lock
     time_per_span = (1e6 * (total_time.to_f / span_count.to_f)).round(2)
-    puts "#{span_count} spans #{percent_done}% done #{total_time.round(2)} seconds (#{time_per_span} us/span)"
+    puts "#{span_count} spans #{percent_done}% done #{total_time.round(2)} seconds (#{time_per_span} µs/span)"
     is_done = done
     mutex.unlock
     Thread.exit if is_done

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -149,7 +149,10 @@ module LightStep
       raise ConfigurationError, "component_name must be a string" unless String === component_name
       raise ConfigurationError, "component_name cannot be blank"  if component_name.empty?
 
-      transport = Transport::HTTPJSON.new(access_token: access_token) if !access_token.nil?
+      if transport.nil? and !access_token.nil?
+        transport = Transport::HTTPJSON.new(access_token: access_token)
+      end
+
       raise ConfigurationError, "you must provide an access token or a transport" if transport.nil?
       raise ConfigurationError, "#{transport} is not a LightStep transport class" if !(LightStep::Transport::Base === transport)
 


### PR DESCRIPTION
If you explicitly pass in a transport and an access token to the tracer,
a new transport is created with the access token instead of using the
supplied transport.