### PR TITLE
Allow http_json transport to re-use connections

### DIFF
--- a/spec/http_json_spec.rb
+++ b/spec/http_json_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'thread'
+require 'rack'
+require 'rack/server'
+
+class App
+  attr_reader :mutex, :calls
+
+  def initialize
+    @mutex = Mutex.new
+    @calls = 0
+  end
+
+  def call(env)
+    # Note we are not unlocking...
+    @calls += 1
+
+    @mutex.lock
+    [200, {}, ["application"]]
+  end
+end
+
+
+describe LightStep::Transport::HTTPJSON do
+  it 'requires an access token' do
+    expect { LightStep::Transport::HTTPJSON.new }.to raise_error(ArgumentError)
+  end
+
+  it 'is thread safe' do
+    app = App.new
+    router_thread = Thread.new do
+      Thread.abort_on_exception = true
+      Rack::Server.start(app: app, Port: 9001)
+    end
+
+    # Let the server startup
+    sleep 0.250
+
+    t = LightStep::Transport::HTTPJSON.new host: "127.0.0.1", port: "9001", encryption: false, access_token: "foo"
+
+    app.mutex.lock
+
+    report_a = Thread.new do
+      t.report hello: true
+    end
+
+    report_b = Thread.new do
+      t.report hello: true
+    end
+
+    sleep 0.250
+
+    # Only one thread will have been able to call
+    expect(app.calls).to eq(1)
+
+    router_thread.terminate
+    report_a.terminate
+    report_b.terminate
+  end
+end


### PR DESCRIPTION
While it appears that some care was taken to add `Connection: keep-alive`, the https object itself is thrown away at the end of the method call.

This change is an attempt to reuse the https object taking care to ensure the transport remains threadsafe.