### PR TITLE
ActiveSupport::Notification support for reporting instrumentation

### DIFF
--- a/lib/lightstep.rb
+++ b/lib/lightstep.rb
@@ -43,5 +43,6 @@ module LightStep
   end
 end
 
+require 'lightstep/instrumentation'
 require 'lightstep/tracer'
 require 'lightstep/global_tracer'

--- a/lib/lightstep/instrumentation.rb
+++ b/lib/lightstep/instrumentation.rb
@@ -1,0 +1,41 @@
+module LightStep
+  # Instrument an operation. This is may be called by any LightStep component to
+  # record an instrumentation event. This is a compatible API to
+  # ActiveSupport::Notifications.
+  #
+  # event   - Name of the event as a symbol. The event is published under the
+  #           lightstep namespace automatically.
+  # payload - Hash payload for the event. Available keys are based on the event
+  #           being published.
+  #
+  # Returns the result of executing the block.
+  def self.instrument(event, payload = {}, &block)
+    if @instrumenter
+      block ||= proc {}
+      @instrumenter.instrument("#{event}.lightstep", payload, &block)
+    elsif block
+      block.call(payload)
+    end
+  end
+
+  # The object that receives instrument messages. This is AS::Notifications by
+  # default but may be set to any object that responds to #instrument.
+  #
+  # Returns an object that responds to #instrument or nil if no instrumentation
+  # backend is configured.
+  def self.instrumenter
+    @instrumenter
+  end
+
+  # Configure the instrumentation backend that will receive events. The object
+  # must respond to #instrument.
+  def self.instrumenter=(object)
+    @instrumenter = object
+  end
+
+  # If AS::Notifications is available, use it as the instrumentation backend by
+  # default. Set LightStep.instrumenter = nil explicitly to disable this.
+  if defined?(ActiveSupport::Notifications)
+    @instrumenter = ActiveSupport::Notifications
+  end
+end

--- a/lib/lightstep/reporter.rb
+++ b/lib/lightstep/reporter.rb
@@ -74,10 +74,12 @@ module LightStep
       @report_start_time = now
 
       begin
-        @transport.report(report_request)
+        LightStep.instrument("flush", report: report_request) do
+          @transport.report(report_request)
+        end
       rescue
-	# an error occurs, add the previous dropped_spans and count of spans
-	# that would have been recorded
+        # an error occurs, add the previous dropped_spans and count of spans
+        # that would have been recorded
         @dropped_spans.increment(dropped_spans + span_records.length)
       end
     end

--- a/lightstep.gemspec
+++ b/lightstep.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bump', '~> 0.5'
   spec.add_development_dependency 'simplecov', '~> 0.12.0'
   spec.add_development_dependency 'timecop', '~> 0.8.0'
+  spec.add_development_dependency 'activesupport', '~> 5.1'
 end

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'spec_helper'
 
 describe LightStep do
@@ -515,5 +516,25 @@ describe LightStep do
     records = result[:span_records]
     expect(records[0][:span_name]).to eq("5")
     expect(records[1][:span_name]).to eq("[:foo]")
+  end
+
+  it 'should delivery instrumentation notifications' do
+    tracer = init_test_tracer
+    event_payload = nil
+
+    tracer.start_span('span').finish
+
+    subscription = LightStep.instrumenter.subscribe "flush.lightstep" do |name, start_time, end_time, id, payload|
+      event_payload = payload
+    end
+
+    begin
+      tracer.flush
+    ensure
+      LightStep.instrumenter.unsubscribe subscription
+    end
+
+    expect(event_payload).to be_a(Hash)
+    expect(event_payload[:report][:span_records].length).to eq(1)
   end
 end

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -1,4 +1,3 @@
-require 'active_support'
 require 'spec_helper'
 
 describe LightStep do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@
 require 'simplecov'
 SimpleCov.start
 require 'pp'
+require 'active_support'
 require 'lightstep'
 require 'timecop'
 


### PR DESCRIPTION
It can be helpful to know if your application is correctly reporting traces to the lightstep collector.

This change includes optional support for subscribing to reporting events. You can see the test for a minimal example, but you might do something more like this:

```ruby
ActiveSupport::Notifications.subscribe("flush.lightstep") do |name, start_time, end_time, id, payload |
  statsd.increment("lightstep.errors") if payload[:exception]
  statsd.timing("lightstep.reporting.time", 1_000*(end_time - start_time))
end
```

It is important for callers to be aware that these events are usually delivered from the lightstep reporting thread. `ActiveSupport::Notifications` is thread-safe itself but your reporting tools may not be.

This does introduce a "development" dependency on `activesupport` for testing. Instrumentation is gracefully ignored if it is not available.

