### PR TITLE
Add support for follows from

### DIFF
--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -59,14 +59,19 @@ module LightStep
     # @param child_of [SpanContext] SpanContext that acts as a parent to
     #        the newly-started Span. If a Span instance is provided, its
     #        .span_context is automatically substituted.
+    # @param references [Array<SpanContext>] An array of SpanContexts that
+    #         identify any parent SpanContexts of newly-started Span. If Spans
+    #         are provided, their .span_context is automatically substituted.
     # @param start_time [Time] When the Span started, if not now
     # @param tags [Hash] Tags to assign to the Span at start time
     # @return [Span]
-    def start_span(operation_name, child_of: nil, start_time: nil, tags: nil)
+    def start_span(operation_name, child_of: nil, references: [], start_time: nil, tags: nil)
+
       Span.new(
         tracer: self,
         operation_name: operation_name,
         child_of: child_of,
+        references: references,
         start_micros: start_time.nil? ? LightStep.micros(Time.now) : LightStep.micros(start_time),
         tags: tags,
         max_log_records: max_log_records,

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -79,7 +79,6 @@ module LightStep
     # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY]
     # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
     def inject(span_context, format, carrier)
-      child_of = child_of.span_context if (Span === child_of)
       case format
       when OpenTracing::FORMAT_TEXT_MAP
         inject_to_text_map(span_context, carrier)

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -32,6 +32,46 @@ describe LightStep do
     expect(child_span.span_context.baggage).to eq(parent_span.span_context.baggage)
   end
 
+  it 'should inherit baggage from parent spans' do
+    tracer = init_test_tracer
+    parent_span = tracer.start_span('parent_span')
+    parent_span.set_baggage(test: 'value')
+    child_span = tracer.start_span('child_span', child_of: parent_span)
+    expect(child_span.span_context.baggage).to eq(parent_span.span_context.baggage)
+  end
+
+  it 'should inherit baggage from a single referenced span context (follows_from)' do
+    tracer = init_test_tracer
+    parent_span = tracer.start_span('parent_span')
+    parent_span.set_baggage(test: 'value')
+    child_span = tracer.start_span('child_span', references: parent_span)
+    expect(child_span.span_context.baggage).to eq(parent_span.span_context.baggage)
+  end
+
+  it 'should inherit baggage from referenced span contexts (follows_from)' do
+    tracer = init_test_tracer
+    parent_span = tracer.start_span('parent_span')
+    parent_span.set_baggage(test: 'value')
+    child_span = tracer.start_span('child_span', references: [parent_span.span_context])
+    expect(child_span.span_context.baggage).to eq(parent_span.span_context.baggage)
+  end
+
+  it 'should inherit baggage from a single referenced span (follows_from)' do
+    tracer = init_test_tracer
+    parent_span = tracer.start_span('parent_span')
+    parent_span.set_baggage(test: 'value')
+    child_span = tracer.start_span('child_span', references: parent_span)
+    expect(child_span.span_context.baggage).to eq(parent_span.span_context.baggage)
+  end
+
+  it 'should inherit baggage from referenced spans (follows_from)' do
+    tracer = init_test_tracer
+    parent_span = tracer.start_span('parent_span')
+    parent_span.set_baggage(test: 'value')
+    child_span = tracer.start_span('child_span', references: [parent_span])
+    expect(child_span.span_context.baggage).to eq(parent_span.span_context.baggage)
+  end
+
   it 'should allow operation_name updates' do
     tracer = init_test_tracer
     span = tracer.start_span('original')


### PR DESCRIPTION
This adds a `references` param to `LightStep.start_span` to facilitate `follows_from` semantics. Only the first reference is accepted if an array is given, and references loses out to `child_of` if both are specified.