### PR TITLE
Add support for opentracing-ruby 0.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     lightstep (0.12.0)
       concurrent-ruby (~> 1.0)
-      opentracing (~> 0.3)
+      opentracing (~> 0.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -49,4 +49,4 @@ DEPENDENCIES
   timecop (~> 0.8.0)
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lightstep (0.12.0)
+    lightstep (0.13.0)
       concurrent-ruby (~> 1.0)
       opentracing (~> 0.4.1)
 

--- a/lib/lightstep.rb
+++ b/lib/lightstep.rb
@@ -45,3 +45,5 @@ end
 
 require 'lightstep/tracer'
 require 'lightstep/global_tracer'
+require 'lightstep/scope'
+require 'lightstep/scope_manager'

--- a/lib/lightstep/scope.rb
+++ b/lib/lightstep/scope.rb
@@ -1,4 +1,7 @@
 module LightStep
+  # Scope represents an OpenTracing Scope
+  #
+  # See http://www.opentracing.io for more information.
   class Scope
     attr_reader :span
 
@@ -8,6 +11,8 @@ module LightStep
       @finish_on_close = finish_on_close
     end
 
+    # Mark the end of the active period for the current thread and Scope,
+    # updating the ScopeManager#active in the process.
     def close
       raise(LightStep::Error, 'already closed') if @closed
       @closed = true

--- a/lib/lightstep/scope.rb
+++ b/lib/lightstep/scope.rb
@@ -2,15 +2,17 @@ module LightStep
   class Scope
     attr_reader :span
 
-    def initialize(span:, finish_on_close: true)
+    def initialize(manager:, span:, finish_on_close: true)
+      @manager = manager
       @span = span
       @finish_on_close = finish_on_close
     end
 
     def close
-      raise LightStep::Error.new('already closed') if @closed
+      raise(LightStep::Error, 'already closed') if @closed
       @closed = true
       @span.finish if @finish_on_close
+      @manager.deactivate
     end
   end
 end

--- a/lib/lightstep/scope.rb
+++ b/lib/lightstep/scope.rb
@@ -1,0 +1,16 @@
+module LightStep
+  class Scope
+    attr_reader :span
+
+    def initialize(span:, finish_on_close: true)
+      @span = span
+      @finish_on_close = finish_on_close
+    end
+
+    def close
+      raise LightStep::Error.new('already closed') if @closed
+      @closed = true
+      @span.finish if @finish_on_close
+    end
+  end
+end

--- a/lib/lightstep/scope_manager.rb
+++ b/lib/lightstep/scope_manager.rb
@@ -1,11 +1,15 @@
 module LightStep
   class ScopeManager
     def activate(span:, finish_on_close: true)
-      @scope = LightStep::Scope.new(span: span, finish_on_close: finish_on_close)
+      @scope = LightStep::Scope.new(manager: self, span: span, finish_on_close: finish_on_close)
     end
 
     def active
       @scope if @scope
+    end
+
+    def deactivate
+      @scope = nil
     end
   end
 end

--- a/lib/lightstep/scope_manager.rb
+++ b/lib/lightstep/scope_manager.rb
@@ -1,15 +1,22 @@
 module LightStep
   class ScopeManager
+    def initialize
+      @scopes = []
+    end
+
     def activate(span:, finish_on_close: true)
-      @scope = LightStep::Scope.new(manager: self, span: span, finish_on_close: finish_on_close)
+      return active if active && active.span == span
+      scope = LightStep::Scope.new(manager: self, span: span, finish_on_close: finish_on_close)
+      @scopes << scope
+      scope
     end
 
     def active
-      @scope if @scope
+      @scopes.last if @scopes
     end
 
     def deactivate
-      @scope = nil
+      @scopes.pop
     end
   end
 end

--- a/lib/lightstep/scope_manager.rb
+++ b/lib/lightstep/scope_manager.rb
@@ -44,7 +44,11 @@ module LightStep
     end
 
     def add_scope(scope)
-      Thread.current[object_id.to_s] = scopes + [scope]
+      if Thread.current[object_id.to_s].nil?
+        Thread.current[object_id.to_s] = [scope]
+      else
+        Thread.current[object_id.to_s] << scope
+      end
     end
   end
 end

--- a/lib/lightstep/scope_manager.rb
+++ b/lib/lightstep/scope_manager.rb
@@ -12,7 +12,7 @@ module LightStep
     end
 
     def active
-      @scopes.last if @scopes
+      @scopes.last
     end
 
     def deactivate

--- a/lib/lightstep/scope_manager.rb
+++ b/lib/lightstep/scope_manager.rb
@@ -1,9 +1,25 @@
 module LightStep
+  # ScopeManager represents an OpenTracing ScopeManager
+  #
+  # See http://www.opentracing.io for more information.
+  #
+  # The ScopeManager interface abstracts both the activation of Span instances
+  # via ScopeManager#activate and access to an active Span/Scope via
+  # ScopeManager#active
+  #
   class ScopeManager
     def initialize
       @scopes = []
     end
 
+    # Make a span instance active.
+    #
+    # @param span [Span] the Span that should become active
+    # @param finish_on_close [Boolean] whether the Span should automatically be
+    #   finished when Scope#close is called
+    # @return [Scope] instance to control the end of the active period for the
+    #  Span. It is a programming error to neglect to call Scope#close on the
+    #  returned instance.
     def activate(span:, finish_on_close: true)
       return active if active && active.span == span
       scope = LightStep::Scope.new(manager: self, span: span, finish_on_close: finish_on_close)
@@ -11,6 +27,12 @@ module LightStep
       scope
     end
 
+    # @return [Scope] the currently active Scope which can be used to access the
+    # currently active Span.
+    #
+    # If there is a non-null Scope, its wrapped Span becomes an implicit parent
+    # (as Reference#CHILD_OF) of any newly-created Span at Tracer#start_active_span
+    # or Tracer#start_span time.
     def active
       @scopes.last
     end

--- a/lib/lightstep/scope_manager.rb
+++ b/lib/lightstep/scope_manager.rb
@@ -1,0 +1,11 @@
+module LightStep
+  class ScopeManager
+    def activate(span:, finish_on_close: true)
+      @scope = LightStep::Scope.new(span: span, finish_on_close: finish_on_close)
+    end
+
+    def active
+      @scope if @scope
+    end
+  end
+end

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -103,7 +103,8 @@ module LightStep
         child_of: child_of,
         references: references,
         start_time: start_time,
-        tags: tags
+        tags: tags,
+        ignore_active_scope: ignore_active_scope
       )
 
       scope_manager.activate(span: span, finish_on_close: finish_on_close).tap do |scope|
@@ -135,8 +136,14 @@ module LightStep
     #         are provided, their .span_context is automatically substituted.
     # @param start_time [Time] When the Span started, if not now
     # @param tags [Hash] Tags to assign to the Span at start time
+    # @param ignore_active_scope [Boolean] whether to create an implicit
+    #   References#CHILD_OF reference to the ScopeManager#active.
     # @return [Span]
-    def start_span(operation_name, child_of: nil, references: [], start_time: nil, tags: nil)
+    def start_span(operation_name, child_of: nil, references: nil, start_time: nil, tags: nil, ignore_active_scope: false)
+      if child_of.nil? && references.nil? && !ignore_active_scope
+        child_of = active_span
+      end
+
       Span.new(
         tracer: self,
         operation_name: operation_name,

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -111,6 +111,8 @@ module LightStep
       end
     end
 
+    # Returns the span from the active scope, if any.
+    #
     # @return [Span, nil] the active span. This is a shorthand for
     #   `scope_manager.active.span`, and nil will be returned if
     #   Scope#active is nil.

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -107,7 +107,10 @@ module LightStep
       )
 
       scope_manager.activate(span: span, finish_on_close: finish_on_close).tap do |scope|
-        yield scope if block_given?
+        if block_given?
+          yield scope
+          scope.close
+        end
       end
     end
 

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -53,6 +53,72 @@ module LightStep
 
     # TODO(bhs): Support FollowsFrom and multiple references
 
+    # Creates a scope manager or returns the already-created one.
+    #
+    # @return [ScopeManager] the current ScopeManager, which may be a no-op but
+    #   may not be nil.
+    def scope_manager
+      @scope_manager ||= LightStep::ScopeManager.new
+    end
+
+    # Returns a newly started and activated Scope.
+    #
+    # If ScopeManager#active is not nil, no explicit references are provided,
+    # and `ignore_active_scope` is false, then an inferred References#CHILD_OF
+    # reference is created to the ScopeManager#active's SpanContext when
+    # start_active_span is invoked.
+    #
+    # @param operation_name [String] The operation name for the Span
+    # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
+    #        the newly-started Span. If a Span instance is provided, its
+    #        context is automatically substituted. See [Reference] for more
+    #        information.
+    #
+    #   If specified, the `references` parameter must be omitted.
+    # @param references [Array<Reference>] An array of reference
+    #   objects that identify one or more parent SpanContexts.
+    # @param start_time [Time] When the Span started, if not now
+    # @param tags [Hash] Tags to assign to the Span at start time
+    # @param ignore_active_scope [Boolean] whether to create an implicit
+    #   References#CHILD_OF reference to the ScopeManager#active.
+    # @param finish_on_close [Boolean] whether span should automatically be
+    #   finished when Scope#close is called
+    # @yield [Scope] If an optional block is passed to start_active it will
+    #   yield the newly-started Scope. If `finish_on_close` is true then the
+    #   Span will be finished automatically after the block is executed.
+    # @return [Scope] The newly-started and activated Scope
+    def start_active_span(operation_name,
+                          child_of: nil,
+                          references: nil,
+                          start_time: Time.now,
+                          tags: nil,
+                          ignore_active_scope: false,
+                          finish_on_close: true)
+      if child_of.nil? && references.nil? && !ignore_active_scope
+        child_of = active_span
+      end
+
+      span = start_span(
+        operation_name,
+        child_of: child_of,
+        references: references,
+        start_time: start_time,
+        tags: tags
+      )
+
+      scope_manager.activate(span: span, finish_on_close: finish_on_close).tap do |scope|
+        yield scope if block_given?
+      end
+    end
+
+    # @return [Span, nil] the active span. This is a shorthand for
+    #   `scope_manager.active.span`, and nil will be returned if
+    #   Scope#active is nil.
+    def active_span
+      scope = scope_manager.active
+      scope.span if scope
+    end
+
     # Starts a new span.
     #
     # @param operation_name [String] The operation name for the Span

--- a/lib/lightstep/version.rb
+++ b/lib/lightstep/version.rb
@@ -1,3 +1,3 @@
 module LightStep
-  VERSION = '0.12.0'.freeze
+  VERSION = '0.13.0'.freeze
 end

--- a/lightstep.gemspec
+++ b/lightstep.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_dependency 'opentracing', '~> 0.3'
+  spec.add_dependency 'opentracing', '~> 0.4.1'
   spec.add_development_dependency 'rake', '~> 11.3'
   spec.add_development_dependency 'rack', '~> 2.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/spec/lightstep/scope_manager_spec.rb
+++ b/spec/lightstep/scope_manager_spec.rb
@@ -55,6 +55,26 @@ describe 'LightStep:ScopeManager' do
         expect(scope_manager.active).to eq(scope)
       end
     end
+
+    it 'should maintain separate scope stacks per thread' do
+      @t1_activated = false
+
+      ts = []
+      ts << Thread.new do
+        scope_manager.activate(span: instance_spy(LightStep::Span))
+        @t1_activated = true
+      end
+
+      ts << Thread.new do
+        while !@t1_activated do
+          sleep 0.1
+        end
+
+        active_scope = scope_manager.active
+        expect(active_scope).to be_nil
+      end
+      ts.map(&:join)
+    end
   end
 
   describe '#active' do

--- a/spec/lightstep/scope_manager_spec.rb
+++ b/spec/lightstep/scope_manager_spec.rb
@@ -38,13 +38,23 @@ describe 'LightStep:ScopeManager' do
       let(:span) { instance_spy(LightStep::Span) }
 
       before(:each) do
-        scope_manager.activate(span: span)
+        @scope = scope_manager.activate(span: span)
       end
 
       it 'should return the active scope' do
         scope = scope_manager.active
         expect(scope).not_to be_nil
         expect(scope.span).to eq(span)
+      end
+
+      context 'when the active scope was closed' do
+        before(:each) do
+          @scope.close
+        end
+
+        it 'should return nil' do
+          expect(scope_manager.active).to be_nil
+        end
       end
     end
   end

--- a/spec/lightstep/scope_manager_spec.rb
+++ b/spec/lightstep/scope_manager_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'LightStep:ScopeManager' do
+  let(:scope_manager) { LightStep::ScopeManager.new }
+  let(:span) { instance_spy(LightStep::Span) }
+
+  describe '#activate' do
+    let(:scope) { scope_manager.activate(span: span) }
+
+    it 'should return a scope' do
+      expect(scope).to be_instance_of(LightStep::Scope)
+    end
+
+    it 'should set the span on the returned scope' do
+      expect(scope.span).to eq(span)
+    end
+
+    it 'should raise an error when no span is given' do
+      expect { scope_manager.activate }.to raise_error(ArgumentError)
+    end
+
+    context 'when finish_on_close is true' do
+      let(:scope) { scope_manager.activate(span: span, finish_on_close: true) }
+
+      it 'should finish the span when the scope is closed' do
+        expect(span).to receive(:finish)
+        scope.close
+      end
+    end
+  end
+
+  describe '#active' do
+    it 'should return nil' do
+      expect(scope_manager.active).to be_nil
+    end
+
+    context 'when there is an active scope' do
+      let(:span) { instance_spy(LightStep::Span) }
+
+      before(:each) do
+        scope_manager.activate(span: span)
+      end
+
+      it 'should return the active scope' do
+        scope = scope_manager.active
+        expect(scope).not_to be_nil
+        expect(scope.span).to eq(span)
+      end
+    end
+  end
+end

--- a/spec/lightstep/scope_spec.rb
+++ b/spec/lightstep/scope_spec.rb
@@ -1,37 +1,33 @@
 require 'spec_helper'
 
 describe 'LightStep::Scope' do
-  describe '#initialize' do
-    it 'should raise an error when no span is given' do
-      expect { LightStep::Scope.new }.to raise_error(ArgumentError)
-    end
-  end
+  let(:manager) { instance_spy(LightStep::ScopeManager) }
 
   describe '#span' do
     it 'should return the scoped span' do
       expected = instance_spy(LightStep::Span)
-      scope = LightStep::Scope.new(span: expected)
+      scope = LightStep::Scope.new(manager: manager, span: expected)
       expect(scope.span).to eq(expected)
     end
   end
 
   describe '#close' do
     it 'should close the scope' do
-      scope = LightStep::Scope.new(span: instance_spy(LightStep::Span))
+      scope = LightStep::Scope.new(manager: manager, span: instance_spy(LightStep::Span))
       expect { scope.close }.not_to raise_error
       expect { scope.close }.to raise_error(LightStep::Error, 'already closed')
     end
 
     it 'should finish the span' do
       span = instance_spy(LightStep::Span)
-      scope = LightStep::Scope.new(span: span)
+      scope = LightStep::Scope.new(manager: manager, span: span)
       expect(span).to receive(:finish)
       scope.close
     end
 
     context 'when the scope should not finish on close' do
       let(:span) { instance_spy(LightStep::Span) }
-      let(:scope) { LightStep::Scope.new(span: span, finish_on_close: false) }
+      let(:scope) { LightStep::Scope.new(manager: manager, span: span, finish_on_close: false) }
 
       it 'should not close the scope' do
         expect(span).not_to receive(:finish)

--- a/spec/lightstep/scope_spec.rb
+++ b/spec/lightstep/scope_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe 'LightStep::Scope' do
+  describe '#initialize' do
+    it 'should raise an error when no span is given' do
+      expect { LightStep::Scope.new }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#span' do
+    it 'should return the scoped span' do
+      expected = instance_spy(LightStep::Span)
+      scope = LightStep::Scope.new(span: expected)
+      expect(scope.span).to eq(expected)
+    end
+  end
+
+  describe '#close' do
+    it 'should close the scope' do
+      scope = LightStep::Scope.new(span: instance_spy(LightStep::Span))
+      expect { scope.close }.not_to raise_error
+      expect { scope.close }.to raise_error(LightStep::Error, 'already closed')
+    end
+
+    it 'should finish the span' do
+      span = instance_spy(LightStep::Span)
+      scope = LightStep::Scope.new(span: span)
+      expect(span).to receive(:finish)
+      scope.close
+    end
+
+    context 'when the scope should not finish on close' do
+      let(:span) { instance_spy(LightStep::Span) }
+      let(:scope) { LightStep::Scope.new(span: span, finish_on_close: false) }
+
+      it 'should not close the scope' do
+        expect(span).not_to receive(:finish)
+        scope.close
+      end
+    end
+  end
+end

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -577,6 +577,9 @@ describe LightStep do
     end
   end
 
+  # test that start_span properly gets the active scope's span and sets it as the parent of the new span
+  #
+
   describe '#start_active_span' do
     let(:tracer) { init_test_tracer }
 

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -598,6 +598,33 @@ describe LightStep do
       end
     end
 
+    context 'when a block is given' do
+      before(:each) do
+        tracer.start_active_span('some-operation') do |scope|
+          @scope = scope
+          expect(@scope.span.end_micros).to be_nil
+        end
+      end
+
+      it 'should finish the span' do
+        expect(@scope.span.end_micros).not_to be_nil
+      end
+
+    end
+
+    context 'when finish_on_close is false and a block is given' do
+      before(:each) do
+        tracer.start_active_span('some-operation', finish_on_close: false) do |scope|
+          @scope = scope
+          expect(@scope.span.end_micros).to be_nil
+        end
+      end
+
+      it 'should not finish the span after the block finishes yielding' do
+        expect(@scope.span.end_micros).to be_nil
+      end
+    end
+
     context 'when there is an active scope' do
       before(:each) do
         @scope = tracer.start_active_span('some-operation')


### PR DESCRIPTION
_The requested reviewers here shouldn't feel compelled to review, but if you'd like to, please do!_

This is to bring lightstep-tracer-ruby in line with opentracing-ruby 0.4.0: https://github.com/opentracing/opentracing-ruby/commit/4114b64f841d4ff9c7c86bd21c979113bd79b20d

The specification for that changeset in opentracing is here: https://github.com/opentracing/specification/blob/master/rfc/scope_manager.md#scopemanager

LS-5707