### PR TITLE
Support W3C headers

### DIFF
--- a/lib/lightstep/span.rb
+++ b/lib/lightstep/span.rb
@@ -155,7 +155,7 @@ module LightStep
       {
         runtime_guid: tracer.guid,
         span_guid: context.id,
-        trace_guid: context.trace_id,
+        trace_guid: context.trace_id[-16..-1] || context.trace_id, # Hack to ensure the reported ID is <= 16 bytes
         span_name: operation_name,
         attributes: tags.map {|key, value|
           {Key: key.to_s, Value: value}

--- a/lib/lightstep/span.rb
+++ b/lib/lightstep/span.rb
@@ -56,8 +56,9 @@ module LightStep
       ref = ref.context if (Span === ref)
 
       if SpanContext === ref
-        @context = SpanContext.new(id: LightStep.guid, trace_id: ref.trace_id)
+        @context = SpanContext.new(id: LightStep.guid, trace_id: ref.trace_id, trace_state: ref.trace_state)
         set_baggage(ref.baggage)
+
         set_tag(:parent_span_guid, ref.id)
       else
         @context = SpanContext.new(id: LightStep.guid, trace_id: LightStep.guid)
@@ -83,7 +84,8 @@ module LightStep
       @context = SpanContext.new(
         id: context.id,
         trace_id: context.trace_id,
-        baggage: context.baggage.merge({key => value})
+        baggage: context.baggage.merge({key => value}),
+        trace_state: context.trace_state
       )
       self
     end
@@ -94,7 +96,8 @@ module LightStep
       @context = SpanContext.new(
         id: context.id,
         trace_id: context.trace_id,
-        baggage: baggage
+        baggage: baggage,
+        trace_state: context.trace_state
       )
     end
 

--- a/lib/lightstep/span_context.rb
+++ b/lib/lightstep/span_context.rb
@@ -1,12 +1,13 @@
 module LightStep
   # SpanContext holds the data for a span that gets inherited to child spans
   class SpanContext
-    attr_reader :id, :trace_id, :baggage
+    attr_reader :id, :trace_id, :baggage, :trace_state
 
-    def initialize(id:, trace_id:, baggage: {})
+    def initialize(id:, trace_id:, baggage: {}, trace_state: [])
       @id = id.freeze
       @trace_id = trace_id.freeze
       @baggage = baggage.freeze
+      @trace_state = trace_state.freeze
     end
   end
 end

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -457,7 +457,10 @@ describe LightStep do
         expected_traceparent = "00-#{span1.context.trace_id.rjust(32, '0')}-#{span1.context.id.rjust(16, '0')}-01"
         expect(carrier['traceparent']).to eq(expected_traceparent)
 
-        expected_baggage = Base64.urlsafe_encode64('footwear=cleats,umbrella=golf', padding: false)
+        expected_baggage = Base64.urlsafe_encode64(JSON.generate({
+          footwear: 'cleats',
+          umbrella: 'golf'
+        }), padding: false)
         expected_tracestate = "lightstep=#{expected_baggage}"
         expect(carrier['tracestate']).to eq(expected_tracestate)
       end
@@ -471,7 +474,7 @@ describe LightStep do
         tracer.inject(span1.context, OpenTracing::FORMAT_RACK, carrier)
         expect(carrier['ot-baggage-CASE-Sensitivity_Underscores']).to eq('value')
 
-        expected_baggage = Base64.urlsafe_encode64('CASE-Sensitivity_Underscores=value', padding: false)
+        expected_baggage = Base64.urlsafe_encode64('{"CASE-Sensitivity_Underscores":"value"}', padding: false)
         expected_tracestate = "lightstep=#{expected_baggage}"
         expect(carrier['tracestate']).to eq(expected_tracestate)
       end
@@ -486,7 +489,7 @@ describe LightStep do
         expect(carrier['ot-baggage-unsafeheader']).to be_nil
         expect(carrier['ot-baggage-unsafe!@#$%$^&header']).to be_nil
 
-        expected_baggage = Base64.urlsafe_encode64('unsafe!@#$%$^&header=value', padding: false)
+        expected_baggage = Base64.urlsafe_encode64('{"unsafe!@#$%$^&header":"value"}', padding: false)
         expected_tracestate = "lightstep=#{expected_baggage}"
         expect(carrier['tracestate']).to eq(expected_tracestate)
       end
@@ -522,7 +525,10 @@ describe LightStep do
       end
 
       it 'should extract baggage from tracestate' do
-        encoded_baggage = Base64.urlsafe_encode64('umbrella=golf,footwear=cleats', padding: false)
+        encoded_baggage = Base64.urlsafe_encode64(JSON.generate({
+          footwear: 'cleats',
+          umbrella: 'golf'
+        }), padding: false)
         carrier = {
           'HTTP_OT_TRACER_TRACEID' => 'abc',
           'HTTP_OT_TRACER_SPANID' => '123',
@@ -598,7 +604,7 @@ describe LightStep do
     end
 
     it 'should not double-propagate old LightStep tracestate' do
-      encoded_baggage = Base64.urlsafe_encode64('umbrella=golf', padding: false)
+      encoded_baggage = Base64.urlsafe_encode64('{"umbrella":"golf"}', padding: false)
 
       original_carrier = {
         'TRACEPARENT' => valid_traceparent,
@@ -614,7 +620,10 @@ describe LightStep do
       new_carrier = {}
       tracer.inject(span.context, OpenTracing::FORMAT_RACK, new_carrier)
 
-      expected_baggage = Base64.urlsafe_encode64('footwear=cleats,umbrella=golf', padding: false)
+      expected_baggage = Base64.urlsafe_encode64(JSON.generate({
+        umbrella: 'golf',
+        footwear: 'cleats'
+      }), padding: false)
       expect(new_carrier['tracestate']).to eq("lightstep=#{expected_baggage},other=vendor,another=foobar")
     end
 


### PR DESCRIPTION
As the proposed changes are very similar to those [for the go tracer](https://github.com/lightstep/lightstep-tracer-go/pull/184), many of the questions that are still open there also apply here.

One big difference is that in Ruby, we currently store the trace and span IDs as strings. I opted to store the full 32-byte trace ID for now, and then truncate at report time. This seemed a bit hacky and might change with something like #67.