### PR TITLE
Adds conformance test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,5 @@ bump-version:
 publish: build test benchmark bump-version
 	gem push lightstep-`ruby scripts/version.rb`.gem
 
-export PATH := /workspace/gopath/bin:$(PATH)
-conformance:
-	bundle
-	runner ruby conformance_test/client.rb
+conformance: cloudbuild.yaml
+	gcloud builds submit --config cloudbuild.yaml .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test benchmark publish
+.PHONY: build test benchmark publish conformance
 
 build:
 	gem build lightstep.gemspec
@@ -22,3 +22,8 @@ bump-version:
 
 publish: build test benchmark bump-version
 	gem push lightstep-`ruby scripts/version.rb`.gem
+
+export PATH := /workspace/gopath/bin:$(PATH)
+conformance:
+	bundle
+	runner ruby conformance_test/client.rb

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
   - name: 'gcr.io/cloud-builders/git'
     args: ['clone', 'https://github.com/lightstep/conformance.git']
   - name: 'gcr.io/cloud-builders/go:debian'
-    args: ['install', 'github.com/lightstep/conformance/runner']
+    args: ['install', 'github.com/lightstep/conformance/ls_conformance_runner']
     env: ['PROJECT_ROOT=github.com/lightstep']
   - name: 'ruby'
-    args: ['sh', '-c', 'bundle && gopath/bin/runner ruby conformance_test/client.rb']
+    args: ['sh', '-c', 'bundle && gopath/bin/ls_conformance_runner ruby conformance_test/client.rb']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,4 +5,4 @@ steps:
     args: ['install', 'github.com/lightstep/conformance/runner']
     env: ['PROJECT_ROOT=github.com/lightstep']
   - name: 'ruby'
-    args: ['make', 'conformance']
+    args: ['sh', '-c', 'bundle && gopath/bin/runner ruby conformance_test/client.rb']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,8 @@
+steps:
+  - name: 'gcr.io/cloud-builders/git'
+    args: ['clone', 'https://github.com/lightstep/conformance.git']
+  - name: 'gcr.io/cloud-builders/go:debian'
+    args: ['install', 'github.com/lightstep/conformance/runner']
+    env: ['PROJECT_ROOT=github.com/lightstep']
+  - name: 'ruby'
+    args: ['make', 'conformance']

--- a/conformance_test/client.rb
+++ b/conformance_test/client.rb
@@ -1,0 +1,19 @@
+require 'json'
+require 'base64'
+require 'opentracing'
+require 'bundler/setup'
+require 'simplecov'
+SimpleCov.start
+require 'lightstep'
+
+
+tracer = LightStep::Tracer.new(access_token: "invalid", component_name: "test")
+
+body = JSON.parse(STDIN.read)
+span_context = tracer.extract(OpenTracing::FORMAT_TEXT_MAP, body['text_map'])
+
+new_text_map = Hash.new
+tracer.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, new_text_map)
+
+STDOUT.write JSON.generate({"text_map"=> new_text_map})
+


### PR DESCRIPTION
This is a prototype to show how we could test each client library against our conformance suite using google cloud build.

To test this out locally,  install the local build runner via`gcloud components install cloud-build-local` and then run `cloud-build-local --dryrun=false --config=cloudbuild.yaml .`. The test should fail since the ruby lib doesn't implement the binary carrier :) 