### PR TITLE
Delegate start_active_span from singleton tracer

### DIFF
--- a/lib/lightstep.rb
+++ b/lib/lightstep.rb
@@ -15,6 +15,7 @@ module LightStep
 
   def_delegator :instance, :configure
   def_delegator :instance, :start_span
+  def_delegator :instance, :start_active_span
   def_delegator :instance, :disable
   def_delegator :instance, :enable
   def_delegator :instance, :flush


### PR DESCRIPTION
The OpenTracing Ruby gem defines a `start_active_span` method which can
be called on a tracer; the LightStep tracer also defines this method,
but does not delegate to it from the LightStep module.

As a result, if OpenTracing is configured in the most simple manner, as:

```ruby
OpenTracing.global_tracer = LightStep
```

then calling `OpenTracing.start_active_span` fails, as that method does
not exist.

This adds `start_active_span` to the set of methods delegated from
`LightStep` to the underlying tracer, so that that method call will
succeed and be compliant with the OpenTracing interface when configured
as above.