### PR TITLE
B3 context propagation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,32 @@
 version: 2
 
 jobs:
-  test:
+  test-ruby-24:
     docker:
-      - image: circleci/ruby:2
+      - image: circleci/ruby:2.4-stretch
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - gem-cache-v2-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - gem-cache-v2-{{ .Branch }}-
-            - gem-cache-v2-
-      - run:
-          name: "set up environment"
-          command: |
-            echo 'export BUNDLE_PATH="$HOME/project/.bundler_cache"' >> $BASH_ENV
-            source $BASH_ENV
-      - run: bundle
-      - save_cache:
-          paths:
-            - ~/project/.bundler_cache
-          key: gem-cache-v2-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-      - run: make test
+      - run: gem install --no-document bundler && bundle install --jobs=3 --retry=3
+      - run: bundle exec rake
+  test-ruby-25:
+    docker:
+      - image: circleci/ruby:2.5-stretch
+    steps:
+      - checkout
+      - run: gem install --no-document bundler && bundle install --jobs=3 --retry=3
+      - run: bundle exec rake
+  test-ruby-26:
+    docker:
+      - image: circleci/ruby:2.6-stretch
+    steps:
+      - checkout
+      - run: gem install --no-document bundler && bundle install --jobs=3 --retry=3
+      - run: bundle exec rake
 
 workflows:
   version: 2
   test:
     jobs:
-      - test
-
+      - test-ruby-24
+      - test-ruby-25
+      - test-ruby-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.16.0
+### Added
+- The tracer now supports B3 context propagation. Propagation can be set by using the `propagator` keyword argument to `Tracer#configure`. Valid values are `:lightstep` (default), and `:b3`.
+
 ## v0.15.0
 ### Added
 - A Changelog

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  ruby:
-    version: 2.2.3

--- a/lib/lightstep/propagation.rb
+++ b/lib/lightstep/propagation.rb
@@ -1,0 +1,9 @@
+#frozen_string_literal: true
+
+require 'lightstep/propagation/lightstep_propagator'
+require 'lightstep/propagation/b3_propagator'
+
+module LightStep
+  module Propagation
+  end
+end

--- a/lib/lightstep/propagation.rb
+++ b/lib/lightstep/propagation.rb
@@ -5,5 +5,21 @@ require 'lightstep/propagation/b3_propagator'
 
 module LightStep
   module Propagation
+    PROPAGATOR_MAP = {
+      lightstep: LightStepPropagator,
+      b3: B3Propagator
+    }
+
+    class << self
+      # Constructs a propagator instance from the given propagator name. If the
+      # name is unknown returns the LightStepPropagator as a default
+      #
+      # @param [Symbol, String] propagator_name One of :lightstep or :b3
+      # @return [Propagator]
+      def [](propagator_name)
+        klass = PROPAGATOR_MAP[propagator_name.to_sym] || LightStepPropagator
+        klass.new
+      end
+    end
   end
 end

--- a/lib/lightstep/propagation/b3_propagator.rb
+++ b/lib/lightstep/propagation/b3_propagator.rb
@@ -1,0 +1,12 @@
+#frozen_string_literal: true
+
+module LightStep
+  module Propagation
+    class B3Propagator < LightStepPropagator
+      CARRIER_TRACER_STATE_PREFIX = 'x-b3-'
+      CARRIER_SPAN_ID = 'x-b3-spanid'
+      CARRIER_TRACE_ID = 'x-b3-traceid'
+      CARRIER_SAMPLED = 'x-b3-sampled'
+    end
+  end
+end

--- a/lib/lightstep/propagation/b3_propagator.rb
+++ b/lib/lightstep/propagation/b3_propagator.rb
@@ -13,6 +13,14 @@ module LightStep
       def trace_id_from_ctx(ctx)
         ctx.trace_id16
       end
+
+      def sampled_flag_from_ctx(ctx)
+        ctx.sampled? ? '1' : '0'
+      end
+
+      def sampled_flag_from_carrier(carrier)
+        carrier[self.class::CARRIER_SAMPLED] == '1' ? true : false
+      end
     end
   end
 end

--- a/lib/lightstep/propagation/b3_propagator.rb
+++ b/lib/lightstep/propagation/b3_propagator.rb
@@ -7,6 +7,12 @@ module LightStep
       CARRIER_SPAN_ID = 'x-b3-spanid'
       CARRIER_TRACE_ID = 'x-b3-traceid'
       CARRIER_SAMPLED = 'x-b3-sampled'
+
+      private
+
+      def trace_id_from_ctx(ctx)
+        ctx.trace_id16
+      end
     end
   end
 end

--- a/lib/lightstep/propagation/lightstep_propagator.rb
+++ b/lib/lightstep/propagation/lightstep_propagator.rb
@@ -49,8 +49,10 @@ module LightStep
       private
 
       def inject_to_text_map(span_context, carrier)
+        if trace_id = trace_id_from_ctx(span_context)
+          carrier[self.class::CARRIER_TRACE_ID] = trace_id
+        end
         carrier[self.class::CARRIER_SPAN_ID] = span_context.id
-        carrier[self.class::CARRIER_TRACE_ID] = span_context.trace_id unless span_context.trace_id.nil?
         carrier[self.class::CARRIER_SAMPLED] = 'true'
 
         span_context.baggage.each do |key, value|
@@ -81,8 +83,10 @@ module LightStep
       end
 
       def inject_to_rack(span_context, carrier)
+        if trace_id = trace_id_from_ctx(span_context)
+          carrier[self.class::CARRIER_TRACE_ID] = trace_id
+        end
         carrier[self.class::CARRIER_SPAN_ID] = span_context.id
-        carrier[self.class::CARRIER_TRACE_ID] = span_context.trace_id unless span_context.trace_id.nil?
         carrier[self.class::CARRIER_SAMPLED] = 'true'
 
         span_context.baggage.each do |key, value|
@@ -102,6 +106,10 @@ module LightStep
                                                      self.class::CARRIER_BAGGAGE_PREFIX)
           memo
         })
+      end
+
+      def trace_id_from_ctx(ctx)
+        ctx.trace_id
       end
     end
   end

--- a/lib/lightstep/propagation/lightstep_propagator.rb
+++ b/lib/lightstep/propagation/lightstep_propagator.rb
@@ -101,7 +101,9 @@ module LightStep
 
       def extract_from_rack(env)
         extract_from_text_map(env.reduce({}){|memo, (raw_header, value)|
-          header = raw_header.to_s.gsub(/^HTTP_/, '').tr!('_', '-').downcase!
+          header = raw_header.to_s.gsub(/^HTTP_/, '')
+          header.tr!('_', '-')
+          header.downcase!
 
           memo[header] = value if header.start_with?(self.class::CARRIER_TRACER_STATE_PREFIX,
                                                      self.class::CARRIER_BAGGAGE_PREFIX)

--- a/lib/lightstep/propagation/lightstep_propagator.rb
+++ b/lib/lightstep/propagation/lightstep_propagator.rb
@@ -65,8 +65,7 @@ module LightStep
           return nil
         end
 
-        baggage = carrier.reduce({}) do |baggage, tuple|
-          key, value = tuple
+        baggage = carrier.reduce({}) do |baggage, (key, value)|
           if key.start_with?(CARRIER_BAGGAGE_PREFIX)
             plain_key = key.to_s[CARRIER_BAGGAGE_PREFIX.length..key.to_s.length]
             baggage[plain_key] = value
@@ -95,9 +94,8 @@ module LightStep
       end
 
       def extract_from_rack(env)
-        extract_from_text_map(env.reduce({}){|memo, tuple|
-          raw_header, value = tuple
-          header = raw_header.to_s.gsub(/^HTTP_/, '').tr('_', '-').downcase
+        extract_from_text_map(env.reduce({}){|memo, (raw_header, value)|
+          header = raw_header.to_s.gsub(/^HTTP_/, '').tr!('_', '-').downcase!
 
           memo[header] = value if header.start_with?(CARRIER_TRACER_STATE_PREFIX, CARRIER_BAGGAGE_PREFIX)
           memo

--- a/lib/lightstep/propagation/lightstep_propagator.rb
+++ b/lib/lightstep/propagation/lightstep_propagator.rb
@@ -53,7 +53,7 @@ module LightStep
           carrier[self.class::CARRIER_TRACE_ID] = trace_id
         end
         carrier[self.class::CARRIER_SPAN_ID] = span_context.id
-        carrier[self.class::CARRIER_SAMPLED] = 'true'
+        carrier[self.class::CARRIER_SAMPLED] = sampled_flag_from_ctx(span_context)
 
         span_context.baggage.each do |key, value|
           carrier[self.class::CARRIER_BAGGAGE_PREFIX + key] = value
@@ -78,6 +78,7 @@ module LightStep
         SpanContext.new(
           id: carrier[self.class::CARRIER_SPAN_ID],
           trace_id: carrier[self.class::CARRIER_TRACE_ID],
+          sampled: sampled_flag_from_carrier(carrier),
           baggage: baggage,
         )
       end
@@ -87,7 +88,7 @@ module LightStep
           carrier[self.class::CARRIER_TRACE_ID] = trace_id
         end
         carrier[self.class::CARRIER_SPAN_ID] = span_context.id
-        carrier[self.class::CARRIER_SAMPLED] = 'true'
+        carrier[self.class::CARRIER_SAMPLED] = sampled_flag_from_ctx(span_context)
 
         span_context.baggage.each do |key, value|
           if key =~ /[^A-Za-z0-9\-_]/
@@ -110,6 +111,14 @@ module LightStep
 
       def trace_id_from_ctx(ctx)
         ctx.trace_id
+      end
+
+      def sampled_flag_from_ctx(_)
+        'true'
+      end
+
+      def sampled_flag_from_carrier(_)
+        true
       end
     end
   end

--- a/lib/lightstep/propagation/lightstep_propagator.rb
+++ b/lib/lightstep/propagation/lightstep_propagator.rb
@@ -1,0 +1,108 @@
+#frozen_string_literal: true
+
+module LightStep
+  module Propagation
+    class LightStepPropagator
+      CARRIER_TRACER_STATE_PREFIX = 'ot-tracer-'.freeze
+      CARRIER_BAGGAGE_PREFIX = 'ot-baggage-'.freeze
+      CARRIER_SPAN_ID = (CARRIER_TRACER_STATE_PREFIX + 'spanid').freeze
+      CARRIER_TRACE_ID = (CARRIER_TRACER_STATE_PREFIX + 'traceid').freeze
+      CARRIER_SAMPLED = (CARRIER_TRACER_STATE_PREFIX + 'sampled').freeze
+
+      # Inject a SpanContext into the given carrier
+      #
+      # @param spancontext [SpanContext]
+      # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY]
+      # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
+      def inject(span_context, format, carrier)
+        case format
+        when OpenTracing::FORMAT_TEXT_MAP
+          inject_to_text_map(span_context, carrier)
+        when OpenTracing::FORMAT_BINARY
+          warn 'Binary inject format not yet implemented'
+        when OpenTracing::FORMAT_RACK
+          inject_to_rack(span_context, carrier)
+        else
+          warn 'Unknown inject format'
+        end
+      end
+
+      # Extract a SpanContext from a carrier
+      # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
+      # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
+      # @return [SpanContext] the extracted SpanContext or nil if none could be found
+      def extract(format, carrier)
+        case format
+        when OpenTracing::FORMAT_TEXT_MAP
+          extract_from_text_map(carrier)
+        when OpenTracing::FORMAT_BINARY
+          warn 'Binary join format not yet implemented'
+          nil
+        when OpenTracing::FORMAT_RACK
+          extract_from_rack(carrier)
+        else
+          warn 'Unknown join format'
+          nil
+        end
+      end
+
+      private
+
+      def inject_to_text_map(span_context, carrier)
+        carrier[CARRIER_SPAN_ID] = span_context.id
+        carrier[CARRIER_TRACE_ID] = span_context.trace_id unless span_context.trace_id.nil?
+        carrier[CARRIER_SAMPLED] = 'true'
+
+        span_context.baggage.each do |key, value|
+          carrier[CARRIER_BAGGAGE_PREFIX + key] = value
+        end
+      end
+
+      def extract_from_text_map(carrier)
+        # If the carrier does not have both the span_id and trace_id key
+        # skip the processing and just return a normal span
+        if !carrier.has_key?(CARRIER_SPAN_ID) || !carrier.has_key?(CARRIER_TRACE_ID)
+          return nil
+        end
+
+        baggage = carrier.reduce({}) do |baggage, tuple|
+          key, value = tuple
+          if key.start_with?(CARRIER_BAGGAGE_PREFIX)
+            plain_key = key.to_s[CARRIER_BAGGAGE_PREFIX.length..key.to_s.length]
+            baggage[plain_key] = value
+          end
+          baggage
+        end
+        SpanContext.new(
+          id: carrier[CARRIER_SPAN_ID],
+          trace_id: carrier[CARRIER_TRACE_ID],
+          baggage: baggage,
+        )
+      end
+
+      def inject_to_rack(span_context, carrier)
+        carrier[CARRIER_SPAN_ID] = span_context.id
+        carrier[CARRIER_TRACE_ID] = span_context.trace_id unless span_context.trace_id.nil?
+        carrier[CARRIER_SAMPLED] = 'true'
+
+        span_context.baggage.each do |key, value|
+          if key =~ /[^A-Za-z0-9\-_]/
+            # TODO: log the error internally
+            next
+          end
+          carrier[CARRIER_BAGGAGE_PREFIX + key] = value
+        end
+      end
+
+      def extract_from_rack(env)
+        extract_from_text_map(env.reduce({}){|memo, tuple|
+          raw_header, value = tuple
+          header = raw_header.to_s.gsub(/^HTTP_/, '').tr('_', '-').downcase
+
+          memo[header] = value if header.start_with?(CARRIER_TRACER_STATE_PREFIX, CARRIER_BAGGAGE_PREFIX)
+          memo
+        })
+      end
+    end
+  end
+end

--- a/lib/lightstep/propagation/lightstep_propagator.rb
+++ b/lib/lightstep/propagation/lightstep_propagator.rb
@@ -3,11 +3,11 @@
 module LightStep
   module Propagation
     class LightStepPropagator
-      CARRIER_TRACER_STATE_PREFIX = 'ot-tracer-'.freeze
-      CARRIER_BAGGAGE_PREFIX = 'ot-baggage-'.freeze
-      CARRIER_SPAN_ID = (CARRIER_TRACER_STATE_PREFIX + 'spanid').freeze
-      CARRIER_TRACE_ID = (CARRIER_TRACER_STATE_PREFIX + 'traceid').freeze
-      CARRIER_SAMPLED = (CARRIER_TRACER_STATE_PREFIX + 'sampled').freeze
+      CARRIER_TRACER_STATE_PREFIX = 'ot-tracer-'
+      CARRIER_SPAN_ID = 'ot-tracer-spanid'
+      CARRIER_TRACE_ID = 'ot-tracer-traceid'
+      CARRIER_SAMPLED = 'ot-tracer-sampled'
+      CARRIER_BAGGAGE_PREFIX = 'ot-baggage-'
 
       # Inject a SpanContext into the given carrier
       #
@@ -49,47 +49,48 @@ module LightStep
       private
 
       def inject_to_text_map(span_context, carrier)
-        carrier[CARRIER_SPAN_ID] = span_context.id
-        carrier[CARRIER_TRACE_ID] = span_context.trace_id unless span_context.trace_id.nil?
-        carrier[CARRIER_SAMPLED] = 'true'
+        carrier[self.class::CARRIER_SPAN_ID] = span_context.id
+        carrier[self.class::CARRIER_TRACE_ID] = span_context.trace_id unless span_context.trace_id.nil?
+        carrier[self.class::CARRIER_SAMPLED] = 'true'
 
         span_context.baggage.each do |key, value|
-          carrier[CARRIER_BAGGAGE_PREFIX + key] = value
+          carrier[self.class::CARRIER_BAGGAGE_PREFIX + key] = value
         end
       end
 
       def extract_from_text_map(carrier)
         # If the carrier does not have both the span_id and trace_id key
         # skip the processing and just return a normal span
-        if !carrier.has_key?(CARRIER_SPAN_ID) || !carrier.has_key?(CARRIER_TRACE_ID)
+        if !carrier.has_key?(self.class::CARRIER_SPAN_ID) || !carrier.has_key?(self.class::CARRIER_TRACE_ID)
           return nil
         end
 
         baggage = carrier.reduce({}) do |baggage, (key, value)|
-          if key.start_with?(CARRIER_BAGGAGE_PREFIX)
-            plain_key = key.to_s[CARRIER_BAGGAGE_PREFIX.length..key.to_s.length]
+          if key.start_with?(self.class::CARRIER_BAGGAGE_PREFIX)
+            plain_key = key.to_s[self.class::CARRIER_BAGGAGE_PREFIX.length..key.to_s.length]
             baggage[plain_key] = value
           end
           baggage
         end
+
         SpanContext.new(
-          id: carrier[CARRIER_SPAN_ID],
-          trace_id: carrier[CARRIER_TRACE_ID],
+          id: carrier[self.class::CARRIER_SPAN_ID],
+          trace_id: carrier[self.class::CARRIER_TRACE_ID],
           baggage: baggage,
         )
       end
 
       def inject_to_rack(span_context, carrier)
-        carrier[CARRIER_SPAN_ID] = span_context.id
-        carrier[CARRIER_TRACE_ID] = span_context.trace_id unless span_context.trace_id.nil?
-        carrier[CARRIER_SAMPLED] = 'true'
+        carrier[self.class::CARRIER_SPAN_ID] = span_context.id
+        carrier[self.class::CARRIER_TRACE_ID] = span_context.trace_id unless span_context.trace_id.nil?
+        carrier[self.class::CARRIER_SAMPLED] = 'true'
 
         span_context.baggage.each do |key, value|
           if key =~ /[^A-Za-z0-9\-_]/
             # TODO: log the error internally
             next
           end
-          carrier[CARRIER_BAGGAGE_PREFIX + key] = value
+          carrier[self.class::CARRIER_BAGGAGE_PREFIX + key] = value
         end
       end
 
@@ -97,7 +98,8 @@ module LightStep
         extract_from_text_map(env.reduce({}){|memo, (raw_header, value)|
           header = raw_header.to_s.gsub(/^HTTP_/, '').tr!('_', '-').downcase!
 
-          memo[header] = value if header.start_with?(CARRIER_TRACER_STATE_PREFIX, CARRIER_BAGGAGE_PREFIX)
+          memo[header] = value if header.start_with?(self.class::CARRIER_TRACER_STATE_PREFIX,
+                                                     self.class::CARRIER_BAGGAGE_PREFIX)
           memo
         })
       end

--- a/lib/lightstep/span_context.rb
+++ b/lib/lightstep/span_context.rb
@@ -3,14 +3,16 @@
 module LightStep
   # SpanContext holds the data for a span that gets inherited to child spans
   class SpanContext
-    attr_reader :id, :trace_id, :trace_id16, :baggage
+    attr_reader :id, :trace_id, :trace_id16, :sampled, :baggage
+    alias_method :sampled?, :sampled
 
     ZERO_PADDING = '0' * 16
 
-    def initialize(id:, trace_id:, baggage: {})
+    def initialize(id:, trace_id:, sampled: true, baggage: {})
       @id = id.freeze
       @trace_id16 = pad_id(trace_id).freeze
       @trace_id = truncate_id(trace_id).freeze
+      @sampled = sampled
       @baggage = baggage.freeze
     end
 

--- a/lib/lightstep/span_context.rb
+++ b/lib/lightstep/span_context.rb
@@ -1,12 +1,29 @@
+#frozen_string_literal: true
+
 module LightStep
   # SpanContext holds the data for a span that gets inherited to child spans
   class SpanContext
-    attr_reader :id, :trace_id, :baggage
+    attr_reader :id, :trace_id, :trace_id16, :baggage
+
+    ZERO_PADDING = '0' * 16
 
     def initialize(id:, trace_id:, baggage: {})
       @id = id.freeze
-      @trace_id = trace_id.freeze
+      @trace_id16 = pad_id(trace_id).freeze
+      @trace_id = truncate_id(trace_id).freeze
       @baggage = baggage.freeze
+    end
+
+    private
+
+    def truncate_id(id)
+      return id unless id && id.size == 32
+      id[16..-1]
+    end
+
+    def pad_id(id)
+      return id unless id && id.size == 16
+      "#{ZERO_PADDING}#{id}"
     end
   end
 end

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -239,7 +239,11 @@ module LightStep
 
     protected
 
-    def configure(component_name:, access_token: nil, transport: nil, tags: {}, propagator: nil)
+    def configure(component_name:,
+                  access_token: nil,
+                  transport: nil, tags: {},
+                  propagator: Propagation::LightStepPropagator.new)
+
       raise ConfigurationError, "component_name must be a string" unless component_name.is_a?(String)
       raise ConfigurationError, "component_name cannot be blank"  if component_name.empty?
 

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -28,14 +28,15 @@ module LightStep
     # @param access_token [String] The project access token when pushing to LightStep
     # @param transport [LightStep::Transport] How the data should be transported
     # @param tags [Hash] Tracer-level tags
-    # @param propagator [Propagator] Propagator to pass context over process boundaries
+    # @param propagator [Propagator] Symbol one of :lightstep, :b3 indicating the propgator
+    #   to use
     # @return LightStep::Tracer
     # @raise LightStep::ConfigurationError if the group name or access token is not a valid string.
     def initialize(component_name:,
                    access_token: nil,
                    transport: nil,
                    tags: {},
-                   propagator: Propagation::LightStepPropagator.new)
+                   propagator: :lightstep)
       configure(component_name: component_name,
                 access_token: access_token,
                 transport: transport,
@@ -242,7 +243,7 @@ module LightStep
     def configure(component_name:,
                   access_token: nil,
                   transport: nil, tags: {},
-                  propagator: Propagation::LightStepPropagator.new)
+                  propagator: :lightstep)
 
       raise ConfigurationError, "component_name must be a string" unless component_name.is_a?(String)
       raise ConfigurationError, "component_name cannot be blank"  if component_name.empty?
@@ -254,7 +255,7 @@ module LightStep
       raise ConfigurationError, "you must provide an access token or a transport" if transport.nil?
       raise ConfigurationError, "#{transport} is not a LightStep transport class" if !(LightStep::Transport::Base === transport)
 
-      @propagator = propagator
+      @propagator = Propagation[propagator]
 
       @guid = LightStep.guid
 

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -5,6 +5,7 @@ require 'opentracing'
 
 require 'lightstep/span'
 require 'lightstep/reporter'
+require 'lightstep/propagation/lightstep_propagator'
 require 'lightstep/transport/http_json'
 require 'lightstep/transport/nil'
 require 'lightstep/transport/callback'
@@ -14,6 +15,11 @@ module LightStep
     class Error < LightStep::Error; end
     class ConfigurationError < LightStep::Tracer::Error; end
 
+    DEFAULT_MAX_LOG_RECORDS = 1000
+    MIN_MAX_LOG_RECORDS = 1
+    DEFAULT_MAX_SPAN_RECORDS = 1000
+    MIN_MAX_SPAN_RECORDS = 1
+
     attr_reader :access_token, :guid
 
     # Initialize a new tracer. Either an access_token or a transport must be
@@ -22,10 +28,19 @@ module LightStep
     # @param access_token [String] The project access token when pushing to LightStep
     # @param transport [LightStep::Transport] How the data should be transported
     # @param tags [Hash] Tracer-level tags
+    # @param propagator [Propagator] Propagator to pass context over process boundaries
     # @return LightStep::Tracer
     # @raise LightStep::ConfigurationError if the group name or access token is not a valid string.
-    def initialize(component_name:, access_token: nil, transport: nil, tags: {})
-      configure(component_name: component_name, access_token: access_token, transport: transport, tags: tags)
+    def initialize(component_name:,
+                   access_token: nil,
+                   transport: nil,
+                   tags: {},
+                   propagator: Propagation::LightStepPropagator.new)
+      configure(component_name: component_name,
+                access_token: access_token,
+                transport: transport,
+                tags: tags,
+                propagator: propagator)
     end
 
     def max_log_records
@@ -172,22 +187,14 @@ module LightStep
       end
     end
 
+
     # Inject a SpanContext into the given carrier
     #
     # @param spancontext [SpanContext]
     # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY]
     # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
     def inject(span_context, format, carrier)
-      case format
-      when OpenTracing::FORMAT_TEXT_MAP
-        inject_to_text_map(span_context, carrier)
-      when OpenTracing::FORMAT_BINARY
-        warn 'Binary inject format not yet implemented'
-      when OpenTracing::FORMAT_RACK
-        inject_to_rack(span_context, carrier)
-      else
-        warn 'Unknown inject format'
-      end
+      @propagator.inject(span_context, format, carrier)
     end
 
     # Extract a SpanContext from a carrier
@@ -195,18 +202,7 @@ module LightStep
     # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
     # @return [SpanContext] the extracted SpanContext or nil if none could be found
     def extract(format, carrier)
-      case format
-      when OpenTracing::FORMAT_TEXT_MAP
-        extract_from_text_map(carrier)
-      when OpenTracing::FORMAT_BINARY
-        warn 'Binary join format not yet implemented'
-        nil
-      when OpenTracing::FORMAT_RACK
-        extract_from_rack(carrier)
-      else
-        warn 'Unknown join format'
-        nil
-      end
+      @propagator.extract(format, carrier)
     end
 
     # @return true if the tracer is enabled
@@ -243,7 +239,7 @@ module LightStep
 
     protected
 
-    def configure(component_name:, access_token: nil, transport: nil, tags: {})
+    def configure(component_name:, access_token: nil, transport: nil, tags: {}, propagator: nil)
       raise ConfigurationError, "component_name must be a string" unless component_name.is_a?(String)
       raise ConfigurationError, "component_name cannot be blank"  if component_name.empty?
 
@@ -254,6 +250,9 @@ module LightStep
       raise ConfigurationError, "you must provide an access token or a transport" if transport.nil?
       raise ConfigurationError, "#{transport} is not a LightStep transport class" if !(LightStep::Transport::Base === transport)
 
+      #@todo: check propagator type
+      @propagator = propagator
+
       @guid = LightStep.guid
 
       @reporter = LightStep::Reporter.new(
@@ -263,76 +262,6 @@ module LightStep
         component_name: component_name,
         tags: tags
       )
-    end
-
-    private
-
-    CARRIER_TRACER_STATE_PREFIX = 'ot-tracer-'.freeze
-    CARRIER_BAGGAGE_PREFIX = 'ot-baggage-'.freeze
-
-    CARRIER_SPAN_ID = (CARRIER_TRACER_STATE_PREFIX + 'spanid').freeze
-    CARRIER_TRACE_ID = (CARRIER_TRACER_STATE_PREFIX + 'traceid').freeze
-    CARRIER_SAMPLED = (CARRIER_TRACER_STATE_PREFIX + 'sampled').freeze
-
-    DEFAULT_MAX_LOG_RECORDS = 1000
-    MIN_MAX_LOG_RECORDS = 1
-    DEFAULT_MAX_SPAN_RECORDS = 1000
-    MIN_MAX_SPAN_RECORDS = 1
-
-    def inject_to_text_map(span_context, carrier)
-      carrier[CARRIER_SPAN_ID] = span_context.id
-      carrier[CARRIER_TRACE_ID] = span_context.trace_id unless span_context.trace_id.nil?
-      carrier[CARRIER_SAMPLED] = 'true'
-
-      span_context.baggage.each do |key, value|
-        carrier[CARRIER_BAGGAGE_PREFIX + key] = value
-      end
-    end
-
-    def extract_from_text_map(carrier)
-      # If the carrier does not have both the span_id and trace_id key
-      # skip the processing and just return a normal span
-      if !carrier.has_key?(CARRIER_SPAN_ID) || !carrier.has_key?(CARRIER_TRACE_ID)
-        return nil
-      end
-
-      baggage = carrier.reduce({}) do |baggage, tuple|
-        key, value = tuple
-        if key.start_with?(CARRIER_BAGGAGE_PREFIX)
-          plain_key = key.to_s[CARRIER_BAGGAGE_PREFIX.length..key.to_s.length]
-          baggage[plain_key] = value
-        end
-        baggage
-      end
-      SpanContext.new(
-        id: carrier[CARRIER_SPAN_ID],
-        trace_id: carrier[CARRIER_TRACE_ID],
-        baggage: baggage,
-      )
-    end
-
-    def inject_to_rack(span_context, carrier)
-      carrier[CARRIER_SPAN_ID] = span_context.id
-      carrier[CARRIER_TRACE_ID] = span_context.trace_id unless span_context.trace_id.nil?
-      carrier[CARRIER_SAMPLED] = 'true'
-
-      span_context.baggage.each do |key, value|
-        if key =~ /[^A-Za-z0-9\-_]/
-          # TODO: log the error internally
-          next
-        end
-        carrier[CARRIER_BAGGAGE_PREFIX + key] = value
-      end
-    end
-
-    def extract_from_rack(env)
-      extract_from_text_map(env.reduce({}){|memo, tuple|
-        raw_header, value = tuple
-        header = raw_header.to_s.gsub(/^HTTP_/, '').tr('_', '-').downcase
-
-        memo[header] = value if header.start_with?(CARRIER_TRACER_STATE_PREFIX, CARRIER_BAGGAGE_PREFIX)
-        memo
-      })
     end
   end
 end

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -5,7 +5,7 @@ require 'opentracing'
 
 require 'lightstep/span'
 require 'lightstep/reporter'
-require 'lightstep/propagation/lightstep_propagator'
+require 'lightstep/propagation'
 require 'lightstep/transport/http_json'
 require 'lightstep/transport/nil'
 require 'lightstep/transport/callback'

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -250,7 +250,6 @@ module LightStep
       raise ConfigurationError, "you must provide an access token or a transport" if transport.nil?
       raise ConfigurationError, "#{transport} is not a LightStep transport class" if !(LightStep::Transport::Base === transport)
 
-      #@todo: check propagator type
       @propagator = propagator
 
       @guid = LightStep.guid

--- a/spec/helpers/rack_helpers.rb
+++ b/spec/helpers/rack_helpers.rb
@@ -1,0 +1,12 @@
+module RackHelpers
+  def to_rack_env(input_hash)
+    input_hash.inject({}) do |memo, (k, v)|
+      memo[to_rack_key(k)] = v
+      memo
+    end
+  end
+
+  def to_rack_key(key)
+    "HTTP_#{key.gsub("-", "_").upcase!}"
+  end
+end

--- a/spec/lightstep/propagation/b3_propagator_spec.rb
+++ b/spec/lightstep/propagation/b3_propagator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe LightStep::Propagation::B3Propagator do
+describe LightStep::Propagation::B3Propagator, :rack_helpers do
   let(:propagator) { subject }
   let(:trace_id_high_bytes) { LightStep.guid }
   let(:trace_id_low_bytes) { LightStep.guid }
@@ -35,171 +35,182 @@ describe LightStep::Propagation::B3Propagator do
     )
   end
 
-  it 'should handle inject/join for text carriers' do
-    carrier = {}
+  describe '#inject' do
+    it 'handles text carriers' do
+      carrier = {}
+      propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
 
-    propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
-    expect(carrier['x-b3-traceid']).to eq(trace_id)
-    expect(carrier['x-b3-spanid']).to eq(span_id)
-    expect(carrier['x-b3-sampled']).to eq('1')
-    expect(carrier['ot-baggage-footwear']).to eq('cleats')
-    expect(carrier['ot-baggage-umbrella']).to eq('golf')
+      expect(carrier['x-b3-traceid']).to eq(trace_id)
+      expect(carrier['x-b3-spanid']).to eq(span_id)
+      expect(carrier['x-b3-sampled']).to eq('1')
+      expect(carrier['ot-baggage-footwear']).to eq('cleats')
+      expect(carrier['ot-baggage-umbrella']).to eq('golf')
+    end
 
-    extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
-    expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
-    expect(extracted_ctx.trace_id16).to eq(trace_id)
-    expect(extracted_ctx.id).to eq(span_id)
-    expect(extracted_ctx.baggage['footwear']).to eq('cleats')
-    expect(extracted_ctx.baggage['umbrella']).to eq('golf')
-  end
+    it 'handles rack carriers' do
+      baggage.merge!({
+        'unsafe!@#$%$^&header' => 'value',
+        'CASE-Sensitivity_Underscores'=> 'value'
+      })
 
-  it 'should handle inject/extract for http requests and rack' do
-    baggage.merge!({
-      'unsafe!@#$%$^&header' => 'value',
-      'CASE-Sensitivity_Underscores'=> 'value'
-    })
+      carrier = {}
+      propagator.inject(span_context, OpenTracing::FORMAT_RACK, carrier)
 
-    carrier = {}
+      expect(carrier['x-b3-traceid']).to eq(trace_id)
+      expect(carrier['x-b3-spanid']).to eq(span_id)
+      expect(carrier['x-b3-sampled']).to eq('1')
+      expect(carrier['ot-baggage-footwear']).to eq('cleats')
+      expect(carrier['ot-baggage-umbrella']).to eq('golf')
+      expect(carrier['ot-baggage-unsafeheader']).to be_nil
+      expect(carrier['ot-baggage-CASE-Sensitivity_Underscores']).to eq('value')
+    end
 
-    propagator.inject(span_context, OpenTracing::FORMAT_RACK, carrier)
-    expect(carrier['x-b3-traceid']).to eq(trace_id)
-    expect(carrier['x-b3-spanid']).to eq(span_id)
-    expect(carrier['x-b3-sampled']).to eq('1')
-    expect(carrier['ot-baggage-footwear']).to eq('cleats')
-    expect(carrier['ot-baggage-umbrella']).to eq('golf')
-    expect(carrier['ot-baggage-unsafeheader']).to be_nil
-    expect(carrier['ot-baggage-CASE-Sensitivity_Underscores']).to eq('value')
+    it 'propagates a 16 byte trace id' do
+      carrier = {}
+      propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
 
-    extracted_ctx = propagator.extract(OpenTracing::FORMAT_RACK, to_rack_env(carrier))
-    expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
-    expect(extracted_ctx.trace_id16).to eq(trace_id)
-    expect(extracted_ctx.id).to eq(span_id)
-    expect(extracted_ctx.baggage['footwear']).to eq('cleats')
-    expect(extracted_ctx.baggage['umbrella']).to eq('golf')
-    expect(extracted_ctx.baggage['unsafe!@#$%$^&header']).to be_nil
-    expect(extracted_ctx.baggage['unsafeheader']).to be_nil
-    expect(extracted_ctx.baggage['case-sensitivity-underscores']).to eq('value')
-  end
+      expect(carrier['x-b3-traceid']).to eq(trace_id)
+      expect(carrier['x-b3-traceid'].size).to eq(32)
+    end
 
-  it 'returns a span context when carrier has both a span_id and trace_id' do
-    extracted_ctx = propagator.extract(
-      OpenTracing::FORMAT_RACK,
-      {'HTTP_X_B3_TRACEID' => trace_id}
-    )
+    it 'pads 8 byte trace_ids' do
+      carrier = {}
 
-    expect(extracted_ctx).to be_nil
-    extracted_ctx = propagator.extract(
-      OpenTracing::FORMAT_RACK,
-      {'HTTP_X_B3_SPANID' => span_id}
-    )
-    expect(extracted_ctx).to be_nil
-
-    # We need both a TRACEID and SPANID; this has both so it should work.
-    extracted_ctx = propagator.extract(
-      OpenTracing::FORMAT_RACK,
-      {'HTTP_X_B3_SPANID' => span_id, 'HTTP_X_B3_TRACEID' => trace_id}
-    )
-    expect(extracted_ctx.id).to eq(span_id)
-    expect(extracted_ctx.trace_id16).to eq(trace_id)
-    expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
-  end
-
-  it 'should be able to extract from a carrier with string or symbol keys' do
-    carrier_with_strings = {
-      'HTTP_X_B3_TRACEID' => trace_id,
-      'HTTP_X_B3_SPANID' => span_id,
-      'HTTP_X_B3_SAMPLED' => '1'
-    }
-    string_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier_with_strings)
-
-    expect(string_ctx).not_to be_nil
-    expect(string_ctx.trace_id16).to eq(trace_id)
-    expect(string_ctx.trace_id).to eq(trace_id_low_bytes)
-    expect(string_ctx).to be_sampled
-    expect(string_ctx.id).to eq(span_id)
-
-    carrier_with_symbols = {
-      HTTP_X_B3_TRACEID: trace_id,
-      HTTP_X_B3_SPANID: span_id,
-      HTTP_X_B3_SAMPLED: '1'
-    }
-    symbol_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier_with_symbols)
-
-    expect(symbol_ctx).not_to be_nil
-    expect(symbol_ctx.trace_id16).to eq(trace_id)
-    expect(symbol_ctx.trace_id).to eq(trace_id_low_bytes)
-    expect(string_ctx).to be_sampled
-    expect(symbol_ctx.id).to eq(span_id)
-  end
-
-  it 'injects a 16 byte trace id' do
-    carrier = {}
-    propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
-
-    expect(carrier['x-b3-traceid']).to eq(trace_id)
-    expect(carrier['x-b3-traceid'].size).to eq(32)
-  end
-
-  it 'extracts a 16 byte trace id' do
-    carrier = {}
-    propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
-
-    extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
-    expect(extracted_ctx.trace_id16).to eq(trace_id)
-    expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
-    expect(extracted_ctx.trace_id.size).to eq(16)
-  end
-
-  it 'should pad an 8 byte trace_id during inject' do
-    carrier = {}
-
-    propagator.inject(span_context_trace_id_low_bytes, OpenTracing::FORMAT_RACK, carrier)
-    expect(carrier['x-b3-traceid']).to eq('0' * 16 << trace_id_low_bytes)
-    expect(carrier['x-b3-spanid']).to eq(span_id)
-  end
-
-  it 'should pad an 8 byte trace_id during extract' do
-    carrier = {
-      'x-b3-traceid' => trace_id_low_bytes,
-      'x-b3-spanid' => span_id,
-      'x-b3-sampled' => '1'
-    }
-
-    extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
-    expect(extracted_ctx.trace_id16).to eq('0' * 16 << trace_id_low_bytes)
-    expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
-  end
-
-  it 'interprets a true sampled flag properly' do
-    carrier = {
-      'x-b3-traceid' => trace_id,
-      'x-b3-spanid' => span_id,
-      'x-b3-sampled' => '1'
-    }
-
-    extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
-    expect(extracted_ctx).to be_sampled
-  end
-
-  it 'interprets a false sampled flag properly' do
-    carrier = {
-      'x-b3-traceid' => trace_id,
-      'x-b3-spanid' => span_id,
-      'x-b3-sampled' => '0'
-    }
-
-    extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
-    expect(extracted_ctx).not_to be_sampled
-  end
-
-  def to_rack_env(input_hash)
-    input_hash.inject({}) do |memo, (k, v)|
-      memo[to_rack_key(k)] = v
-      memo
+      propagator.inject(span_context_trace_id_low_bytes, OpenTracing::FORMAT_RACK, carrier)
+      expect(carrier['x-b3-traceid']).to eq('0' * 16 << trace_id_low_bytes)
+      expect(carrier['x-b3-spanid']).to eq(span_id)
     end
   end
 
-  def to_rack_key(key)
-    "HTTP_#{key.gsub("-", "_").upcase!}"
+  describe '#extract' do
+    it 'handles text carriers' do
+      carrier = {}
+      propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
+      extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+
+      expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
+      expect(extracted_ctx.trace_id16).to eq(trace_id)
+      expect(extracted_ctx.id).to eq(span_id)
+      expect(extracted_ctx.baggage['footwear']).to eq('cleats')
+      expect(extracted_ctx.baggage['umbrella']).to eq('golf')
+    end
+
+    it 'handles rack carriers' do
+      baggage.merge!({
+        'unsafe!@#$%$^&header' => 'value',
+        'CASE-Sensitivity_Underscores'=> 'value'
+      })
+
+      carrier = {}
+      propagator.inject(span_context, OpenTracing::FORMAT_RACK, carrier)
+      extracted_ctx = propagator.extract(OpenTracing::FORMAT_RACK, to_rack_env(carrier))
+
+      expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
+      expect(extracted_ctx.trace_id16).to eq(trace_id)
+      expect(extracted_ctx.id).to eq(span_id)
+      expect(extracted_ctx.baggage['footwear']).to eq('cleats')
+      expect(extracted_ctx.baggage['umbrella']).to eq('golf')
+      expect(extracted_ctx.baggage['unsafe!@#$%$^&header']).to be_nil
+      expect(extracted_ctx.baggage['unsafeheader']).to be_nil
+      expect(extracted_ctx.baggage['case-sensitivity-underscores']).to eq('value')
+    end
+
+    it 'returns a span context when carrier has both a span_id and trace_id' do
+      extracted_ctx = propagator.extract(
+        OpenTracing::FORMAT_RACK,
+        {'HTTP_X_B3_TRACEID' => trace_id}
+      )
+
+      expect(extracted_ctx).to be_nil
+      extracted_ctx = propagator.extract(
+        OpenTracing::FORMAT_RACK,
+        {'HTTP_X_B3_SPANID' => span_id}
+      )
+      expect(extracted_ctx).to be_nil
+
+      # We need both a TRACEID and SPANID; this has both so it should work.
+      extracted_ctx = propagator.extract(
+        OpenTracing::FORMAT_RACK,
+        {'HTTP_X_B3_SPANID' => span_id, 'HTTP_X_B3_TRACEID' => trace_id}
+      )
+      expect(extracted_ctx.id).to eq(span_id)
+      expect(extracted_ctx.trace_id16).to eq(trace_id)
+      expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
+    end
+
+    it 'handles carriers with string keys' do
+      carrier_with_strings = {
+        'HTTP_X_B3_TRACEID' => trace_id,
+        'HTTP_X_B3_SPANID' => span_id,
+        'HTTP_X_B3_SAMPLED' => '1'
+      }
+      string_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier_with_strings)
+
+      expect(string_ctx).not_to be_nil
+      expect(string_ctx.trace_id16).to eq(trace_id)
+      expect(string_ctx.trace_id).to eq(trace_id_low_bytes)
+      expect(string_ctx).to be_sampled
+      expect(string_ctx.id).to eq(span_id)
+    end
+
+    it 'handles carriers symbol keys' do
+      carrier_with_symbols = {
+        HTTP_X_B3_TRACEID: trace_id,
+        HTTP_X_B3_SPANID: span_id,
+        HTTP_X_B3_SAMPLED: '1'
+      }
+      symbol_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier_with_symbols)
+
+      expect(symbol_ctx).not_to be_nil
+      expect(symbol_ctx.trace_id16).to eq(trace_id)
+      expect(symbol_ctx.trace_id).to eq(trace_id_low_bytes)
+      expect(symbol_ctx).to be_sampled
+      expect(symbol_ctx.id).to eq(span_id)
+    end
+
+    it 'pads 8 byte trace_ids' do
+      carrier = {
+        'x-b3-traceid' => trace_id_low_bytes,
+        'x-b3-spanid' => span_id,
+        'x-b3-sampled' => '1'
+      }
+
+      extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+      expect(extracted_ctx.trace_id16).to eq('0' * 16 << trace_id_low_bytes)
+      expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
+    end
+
+    it 'interprets a true sampled flag properly' do
+      carrier = {
+        'x-b3-traceid' => trace_id,
+        'x-b3-spanid' => span_id,
+        'x-b3-sampled' => '1'
+      }
+
+      extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+      expect(extracted_ctx).to be_sampled
+    end
+
+    it 'interprets a false sampled flag properly' do
+      carrier = {
+        'x-b3-traceid' => trace_id,
+        'x-b3-spanid' => span_id,
+        'x-b3-sampled' => '0'
+      }
+
+      extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+      expect(extracted_ctx).not_to be_sampled
+    end
+
+    it 'maintains 8 and 16 byte trace ids' do
+      carrier = {}
+      propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
+
+      extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+      expect(extracted_ctx.trace_id16).to eq(trace_id)
+      expect(extracted_ctx.trace_id16.size).to eq(32)
+      expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
+      expect(extracted_ctx.trace_id.size).to eq(16)
+    end
   end
 end

--- a/spec/lightstep/propagation/b3_propagator_spec.rb
+++ b/spec/lightstep/propagation/b3_propagator_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe LightStep::Propagation::B3Propagator do
   let(:propagator) { subject }
-  let(:trace_id) { LightStep.guid }
+  let(:trace_id_high_bytes) { LightStep.guid }
+  let(:trace_id_low_bytes) { LightStep.guid }
+  let(:trace_id) { [trace_id_high_bytes, trace_id_low_bytes].join }
   let(:span_id) { LightStep.guid }
   let(:baggage) do
     {
@@ -17,6 +19,13 @@ describe LightStep::Propagation::B3Propagator do
       baggage: baggage
     )
   end
+  let(:span_context_trace_id_low_bytes) do
+    LightStep::SpanContext.new(
+      id: span_id,
+      trace_id: trace_id_low_bytes,
+      baggage: baggage
+    )
+  end
 
   it 'should handle inject/join for text carriers' do
     carrier = {}
@@ -28,7 +37,8 @@ describe LightStep::Propagation::B3Propagator do
     expect(carrier['ot-baggage-umbrella']).to eq('golf')
 
     extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
-    expect(extracted_ctx.trace_id).to eq(trace_id)
+    expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
+    expect(extracted_ctx.trace_id16).to eq(trace_id)
     expect(extracted_ctx.id).to eq(span_id)
     expect(extracted_ctx.baggage['footwear']).to eq('cleats')
     expect(extracted_ctx.baggage['umbrella']).to eq('golf')
@@ -51,7 +61,8 @@ describe LightStep::Propagation::B3Propagator do
     expect(carrier['ot-baggage-CASE-Sensitivity_Underscores']).to eq('value')
 
     extracted_ctx = propagator.extract(OpenTracing::FORMAT_RACK, to_rack_env(carrier))
-    expect(extracted_ctx.trace_id).to eq(trace_id)
+    expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
+    expect(extracted_ctx.trace_id16).to eq(trace_id)
     expect(extracted_ctx.id).to eq(span_id)
     expect(extracted_ctx.baggage['footwear']).to eq('cleats')
     expect(extracted_ctx.baggage['umbrella']).to eq('golf')
@@ -79,7 +90,8 @@ describe LightStep::Propagation::B3Propagator do
       {'HTTP_X_B3_SPANID' => span_id, 'HTTP_X_B3_TRACEID' => trace_id}
     )
     expect(extracted_ctx.id).to eq(span_id)
-    expect(extracted_ctx.trace_id).to eq(trace_id)
+    expect(extracted_ctx.trace_id16).to eq(trace_id)
+    expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
   end
 
   it 'should be able to extract from a carrier with string or symbol keys' do
@@ -90,7 +102,8 @@ describe LightStep::Propagation::B3Propagator do
     string_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier_with_strings)
 
     expect(string_ctx).not_to be_nil
-    expect(string_ctx.trace_id).to eq(trace_id)
+    expect(string_ctx.trace_id16).to eq(trace_id)
+    expect(string_ctx.trace_id).to eq(trace_id_low_bytes)
     expect(string_ctx.id).to eq(span_id)
 
     carrier_with_symbols = {
@@ -100,8 +113,47 @@ describe LightStep::Propagation::B3Propagator do
     symbol_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier_with_symbols)
 
     expect(symbol_ctx).not_to be_nil
-    expect(symbol_ctx.trace_id).to eq(trace_id)
+    expect(symbol_ctx.trace_id16).to eq(trace_id)
+    expect(symbol_ctx.trace_id).to eq(trace_id_low_bytes)
     expect(symbol_ctx.id).to eq(span_id)
+  end
+
+  it 'injects a 16 byte trace id' do
+    carrier = {}
+    propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
+
+    expect(carrier['x-b3-traceid']).to eq(trace_id)
+    expect(carrier['x-b3-traceid'].size).to eq(32)
+  end
+
+  it 'extracts a 16 byte trace id' do
+    carrier = {}
+    propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
+
+    extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+    expect(extracted_ctx.trace_id16).to eq(trace_id)
+    expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
+    expect(extracted_ctx.trace_id.size).to eq(16)
+  end
+
+  it 'should pad an 8 byte trace_id during inject' do
+    carrier = {}
+
+    propagator.inject(span_context_trace_id_low_bytes, OpenTracing::FORMAT_RACK, carrier)
+    expect(carrier['x-b3-traceid']).to eq('0' * 16 << trace_id_low_bytes)
+    expect(carrier['x-b3-spanid']).to eq(span_id)
+  end
+
+  it 'should pad an 8 byte trace_id during extract' do
+    carrier = {
+      'x-b3-traceid' => trace_id_low_bytes,
+      'x-b3-spanid' => span_id,
+      'x-b3-sampled' => 'true'
+    }
+
+    extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+    expect(extracted_ctx.trace_id16).to eq('0' * 16 << trace_id_low_bytes)
+    expect(extracted_ctx.trace_id).to eq(trace_id_low_bytes)
   end
 
   def to_rack_env(input_hash)

--- a/spec/lightstep/propagation/b3_propagator_spec.rb
+++ b/spec/lightstep/propagation/b3_propagator_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+describe LightStep::Propagation::B3Propagator do
+  let(:propagator) { subject }
+  let(:trace_id) { LightStep.guid }
+  let(:span_id) { LightStep.guid }
+  let(:baggage) do
+    {
+      'footwear' => 'cleats',
+      'umbrella' => 'golf'
+    }
+  end
+  let(:span_context) do
+    LightStep::SpanContext.new(
+      id: span_id,
+      trace_id: trace_id,
+      baggage: baggage
+    )
+  end
+
+  it 'should handle inject/join for text carriers' do
+    carrier = {}
+
+    propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
+    expect(carrier['x-b3-traceid']).to eq(trace_id)
+    expect(carrier['x-b3-spanid']).to eq(span_id)
+    expect(carrier['ot-baggage-footwear']).to eq('cleats')
+    expect(carrier['ot-baggage-umbrella']).to eq('golf')
+
+    extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+    expect(extracted_ctx.trace_id).to eq(trace_id)
+    expect(extracted_ctx.id).to eq(span_id)
+    expect(extracted_ctx.baggage['footwear']).to eq('cleats')
+    expect(extracted_ctx.baggage['umbrella']).to eq('golf')
+  end
+
+  it 'should handle inject/extract for http requests and rack' do
+    baggage.merge!({
+      'unsafe!@#$%$^&header' => 'value',
+      'CASE-Sensitivity_Underscores'=> 'value'
+    })
+
+    carrier = {}
+
+    propagator.inject(span_context, OpenTracing::FORMAT_RACK, carrier)
+    expect(carrier['x-b3-traceid']).to eq(trace_id)
+    expect(carrier['x-b3-spanid']).to eq(span_id)
+    expect(carrier['ot-baggage-footwear']).to eq('cleats')
+    expect(carrier['ot-baggage-umbrella']).to eq('golf')
+    expect(carrier['ot-baggage-unsafeheader']).to be_nil
+    expect(carrier['ot-baggage-CASE-Sensitivity_Underscores']).to eq('value')
+
+    extracted_ctx = propagator.extract(OpenTracing::FORMAT_RACK, to_rack_env(carrier))
+    expect(extracted_ctx.trace_id).to eq(trace_id)
+    expect(extracted_ctx.id).to eq(span_id)
+    expect(extracted_ctx.baggage['footwear']).to eq('cleats')
+    expect(extracted_ctx.baggage['umbrella']).to eq('golf')
+    expect(extracted_ctx.baggage['unsafe!@#$%$^&header']).to be_nil
+    expect(extracted_ctx.baggage['unsafeheader']).to be_nil
+    expect(extracted_ctx.baggage['case-sensitivity-underscores']).to eq('value')
+  end
+
+  it 'returns a span context when carrier has both a span_id and trace_id' do
+    extracted_ctx = propagator.extract(
+      OpenTracing::FORMAT_RACK,
+      {'HTTP_X_B3_TRACEID' => trace_id}
+    )
+
+    expect(extracted_ctx).to be_nil
+    extracted_ctx = propagator.extract(
+      OpenTracing::FORMAT_RACK,
+      {'HTTP_X_B3_SPANID' => span_id}
+    )
+    expect(extracted_ctx).to be_nil
+
+    # We need both a TRACEID and SPANID; this has both so it should work.
+    extracted_ctx = propagator.extract(
+      OpenTracing::FORMAT_RACK,
+      {'HTTP_X_B3_SPANID' => span_id, 'HTTP_X_B3_TRACEID' => trace_id}
+    )
+    expect(extracted_ctx.id).to eq(span_id)
+    expect(extracted_ctx.trace_id).to eq(trace_id)
+  end
+
+  it 'should be able to extract from a carrier with string or symbol keys' do
+    carrier_with_strings = {
+      'HTTP_X_B3_TRACEID' => trace_id,
+      'HTTP_X_B3_SPANID' => span_id,
+    }
+    string_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier_with_strings)
+
+    expect(string_ctx).not_to be_nil
+    expect(string_ctx.trace_id).to eq(trace_id)
+    expect(string_ctx.id).to eq(span_id)
+
+    carrier_with_symbols = {
+      HTTP_X_B3_TRACEID: trace_id,
+      HTTP_X_B3_SPANID: span_id,
+    }
+    symbol_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier_with_symbols)
+
+    expect(symbol_ctx).not_to be_nil
+    expect(symbol_ctx.trace_id).to eq(trace_id)
+    expect(symbol_ctx.id).to eq(span_id)
+  end
+
+  def to_rack_env(input_hash)
+    input_hash.inject({}) do |memo, (k, v)|
+      memo[to_rack_key(k)] = v
+      memo
+    end
+  end
+
+  def to_rack_key(key)
+    "HTTP_#{key.gsub("-", "_").upcase!}"
+  end
+end

--- a/spec/lightstep/propagation/lightstep_propagator_spec.rb
+++ b/spec/lightstep/propagation/lightstep_propagator_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+describe LightStep::Propagation::LightStepPropagator do
+  let(:propagator) { subject }
+  let(:trace_id) { LightStep.guid }
+  let(:span_id) { LightStep.guid }
+  let(:baggage) do
+    {
+      'footwear' => 'cleats',
+      'umbrella' => 'golf'
+    }
+  end
+  let(:span_context) do
+    LightStep::SpanContext.new(
+      id: span_id,
+      trace_id: trace_id,
+      baggage: baggage
+    )
+  end
+
+  it 'should handle inject/join for text carriers' do
+    carrier = {}
+
+    propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
+    expect(carrier['ot-tracer-traceid']).to eq(trace_id)
+    expect(carrier['ot-tracer-spanid']).to eq(span_id)
+    expect(carrier['ot-baggage-footwear']).to eq('cleats')
+    expect(carrier['ot-baggage-umbrella']).to eq('golf')
+
+    extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+    expect(extracted_ctx.trace_id).to eq(trace_id)
+    expect(extracted_ctx.id).to eq(span_id)
+    expect(extracted_ctx.baggage['footwear']).to eq('cleats')
+    expect(extracted_ctx.baggage['umbrella']).to eq('golf')
+  end
+
+  it 'should handle inject/extract for http requests and rack' do
+    baggage.merge!({
+      'unsafe!@#$%$^&header' => 'value',
+      'CASE-Sensitivity_Underscores'=> 'value'
+    })
+
+    carrier = {}
+
+    propagator.inject(span_context, OpenTracing::FORMAT_RACK, carrier)
+    expect(carrier['ot-tracer-traceid']).to eq(trace_id)
+    expect(carrier['ot-tracer-spanid']).to eq(span_id)
+    expect(carrier['ot-baggage-footwear']).to eq('cleats')
+    expect(carrier['ot-baggage-umbrella']).to eq('golf')
+    expect(carrier['ot-baggage-unsafeheader']).to be_nil
+    expect(carrier['ot-baggage-CASE-Sensitivity_Underscores']).to eq('value')
+
+    extracted_ctx = propagator.extract(OpenTracing::FORMAT_RACK, to_rack_env(carrier))
+    expect(extracted_ctx.trace_id).to eq(trace_id)
+    expect(extracted_ctx.id).to eq(span_id)
+    expect(extracted_ctx.baggage['footwear']).to eq('cleats')
+    expect(extracted_ctx.baggage['umbrella']).to eq('golf')
+    expect(extracted_ctx.baggage['unsafe!@#$%$^&header']).to be_nil
+    expect(extracted_ctx.baggage['unsafeheader']).to be_nil
+    expect(extracted_ctx.baggage['case-sensitivity-underscores']).to eq('value')
+  end
+
+  it 'returns a span context when carrier has both a span_id and trace_id' do
+    extracted_ctx = propagator.extract(
+      OpenTracing::FORMAT_RACK,
+      {'HTTP_OT_TRACER_TRACEID' => trace_id}
+    )
+
+    expect(extracted_ctx).to be_nil
+    extracted_ctx = propagator.extract(
+      OpenTracing::FORMAT_RACK,
+      {'HTTP_OT_TRACER_SPANID' => span_id}
+    )
+    expect(extracted_ctx).to be_nil
+
+    # We need both a TRACEID and SPANID; this has both so it should work.
+    extracted_ctx = propagator.extract(
+      OpenTracing::FORMAT_RACK,
+      {'HTTP_OT_TRACER_SPANID' => span_id, 'HTTP_OT_TRACER_TRACEID' => trace_id}
+    )
+    expect(extracted_ctx.id).to eq(span_id)
+    expect(extracted_ctx.trace_id).to eq(trace_id)
+  end
+
+  it 'should be able to extract from a carrier with string or symbol keys' do
+    carrier_with_strings = {
+      'HTTP_OT_TRACER_TRACEID' => trace_id,
+      'HTTP_OT_TRACER_SPANID' => span_id,
+    }
+    string_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier_with_strings)
+
+    expect(string_ctx).not_to be_nil
+    expect(string_ctx.trace_id).to eq(trace_id)
+    expect(string_ctx.id).to eq(span_id)
+
+    carrier_with_symbols = {
+      HTTP_OT_TRACER_TRACEID: trace_id,
+      HTTP_OT_TRACER_SPANID: span_id,
+    }
+    symbol_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier_with_symbols)
+
+    expect(symbol_ctx).not_to be_nil
+    expect(symbol_ctx.trace_id).to eq(trace_id)
+    expect(symbol_ctx.id).to eq(span_id)
+  end
+
+  def to_rack_env(input_hash)
+    input_hash.inject({}) do |memo, (k, v)|
+      memo[to_rack_key(k)] = v
+      memo
+    end
+  end
+
+  def to_rack_key(key)
+    "HTTP_#{key.gsub("-", "_").upcase!}"
+  end
+end

--- a/spec/lightstep/propagation/lightstep_propagator_spec.rb
+++ b/spec/lightstep/propagation/lightstep_propagator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe LightStep::Propagation::LightStepPropagator do
+describe LightStep::Propagation::LightStepPropagator, :rack_helpers do
   let(:propagator) { subject }
   let(:trace_id) { LightStep.guid }
   let(:padded_trace_id) { '0' * 16 << trace_id }
@@ -19,155 +19,166 @@ describe LightStep::Propagation::LightStepPropagator do
     )
   end
 
-  it 'should handle inject/join for text carriers' do
-    carrier = {}
-
-    propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
-    expect(carrier['ot-tracer-traceid']).to eq(trace_id)
-    expect(carrier['ot-tracer-spanid']).to eq(span_id)
-    expect(carrier['ot-baggage-footwear']).to eq('cleats')
-    expect(carrier['ot-baggage-umbrella']).to eq('golf')
-
-    extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
-    expect(extracted_ctx.trace_id).to eq(trace_id)
-    expect(extracted_ctx.trace_id16).to eq(padded_trace_id)
-    expect(extracted_ctx.id).to eq(span_id)
-    expect(extracted_ctx.baggage['footwear']).to eq('cleats')
-    expect(extracted_ctx.baggage['umbrella']).to eq('golf')
-  end
-
-  it 'should handle inject/extract for http requests and rack' do
-    baggage.merge!({
-      'unsafe!@#$%$^&header' => 'value',
-      'CASE-Sensitivity_Underscores'=> 'value'
-    })
-
-    carrier = {}
-
-    propagator.inject(span_context, OpenTracing::FORMAT_RACK, carrier)
-    expect(carrier['ot-tracer-traceid']).to eq(trace_id)
-    expect(carrier['ot-tracer-spanid']).to eq(span_id)
-    expect(carrier['ot-baggage-footwear']).to eq('cleats')
-    expect(carrier['ot-baggage-umbrella']).to eq('golf')
-    expect(carrier['ot-baggage-unsafeheader']).to be_nil
-    expect(carrier['ot-baggage-CASE-Sensitivity_Underscores']).to eq('value')
-
-    extracted_ctx = propagator.extract(OpenTracing::FORMAT_RACK, to_rack_env(carrier))
-    expect(extracted_ctx.trace_id).to eq(trace_id)
-    expect(extracted_ctx.trace_id16).to eq(padded_trace_id)
-    expect(extracted_ctx.id).to eq(span_id)
-    expect(extracted_ctx.baggage['footwear']).to eq('cleats')
-    expect(extracted_ctx.baggage['umbrella']).to eq('golf')
-    expect(extracted_ctx.baggage['unsafe!@#$%$^&header']).to be_nil
-    expect(extracted_ctx.baggage['unsafeheader']).to be_nil
-    expect(extracted_ctx.baggage['case-sensitivity-underscores']).to eq('value')
-  end
-
-  it 'returns a span context when carrier has both a span_id and trace_id' do
-    extracted_ctx = propagator.extract(
-      OpenTracing::FORMAT_RACK,
-      {'HTTP_OT_TRACER_TRACEID' => trace_id}
-    )
-
-    expect(extracted_ctx).to be_nil
-    extracted_ctx = propagator.extract(
-      OpenTracing::FORMAT_RACK,
-      {'HTTP_OT_TRACER_SPANID' => span_id}
-    )
-    expect(extracted_ctx).to be_nil
-
-    # We need both a TRACEID and SPANID; this has both so it should work.
-    extracted_ctx = propagator.extract(
-      OpenTracing::FORMAT_RACK,
-      {'HTTP_OT_TRACER_SPANID' => span_id, 'HTTP_OT_TRACER_TRACEID' => trace_id}
-    )
-    expect(extracted_ctx.id).to eq(span_id)
-    expect(extracted_ctx.trace_id).to eq(trace_id)
-    expect(extracted_ctx.trace_id16).to eq(padded_trace_id)
-  end
-
-  it 'should be able to extract from a carrier with string or symbol keys' do
-    carrier_with_strings = {
-      'HTTP_OT_TRACER_TRACEID' => trace_id,
-      'HTTP_OT_TRACER_SPANID' => span_id,
-    }
-    string_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier_with_strings)
-
-    expect(string_ctx).not_to be_nil
-    expect(string_ctx.trace_id).to eq(trace_id)
-    expect(string_ctx.trace_id16).to eq(padded_trace_id)
-    expect(string_ctx.id).to eq(span_id)
-
-    carrier_with_symbols = {
-      HTTP_OT_TRACER_TRACEID: trace_id,
-      HTTP_OT_TRACER_SPANID: span_id,
-    }
-    symbol_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier_with_symbols)
-
-    expect(symbol_ctx).not_to be_nil
-    expect(symbol_ctx.trace_id).to eq(trace_id)
-    expect(symbol_ctx.trace_id16).to eq(padded_trace_id)
-    expect(symbol_ctx.id).to eq(span_id)
-  end
-
-  it 'injects an 8 byte trace id' do
-    carrier = {}
-    propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
-
-    expect(carrier['ot-tracer-traceid']).to eq(trace_id)
-    expect(carrier['ot-tracer-traceid'].size).to eq(16)
-  end
-
-  it 'extracts a 8 byte trace id' do
-    trace_id16 = [LightStep.guid, trace_id].join
-
-    carrier = {
-      'ot-tracer-traceid' => trace_id16,
-      'ot-tracer-spanid' => span_id,
-      'ot-tracer-sampled' => 'true'
-    }
-
-    extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
-    expect(extracted_ctx.trace_id16).to eq(trace_id16)
-    expect(extracted_ctx.trace_id).to eq(trace_id)
-    expect(extracted_ctx.trace_id.size).to eq(16)
-  end
-
-  it 'always propagates a true sampled flag' do
-    [true, false].each do |sampled|
-      ctx = LightStep::SpanContext.new(
-        id: span_id,
-        trace_id: trace_id,
-        sampled: sampled,
-        baggage: baggage
-      )
+  describe '#inject' do
+    it 'handles text carriers' do
       carrier = {}
       propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
-      expect(carrier['ot-tracer-sampled']).to eq('true')
+
+      expect(carrier['ot-tracer-traceid']).to eq(trace_id)
+      expect(carrier['ot-tracer-spanid']).to eq(span_id)
+      expect(carrier['ot-baggage-footwear']).to eq('cleats')
+      expect(carrier['ot-baggage-umbrella']).to eq('golf')
+    end
+
+    it 'handles rack carriers' do
+      baggage.merge!({
+        'unsafe!@#$%$^&header' => 'value',
+        'CASE-Sensitivity_Underscores'=> 'value'
+      })
+
+      carrier = {}
+      propagator.inject(span_context, OpenTracing::FORMAT_RACK, carrier)
+
+      expect(carrier['ot-tracer-traceid']).to eq(trace_id)
+      expect(carrier['ot-tracer-spanid']).to eq(span_id)
+      expect(carrier['ot-baggage-footwear']).to eq('cleats')
+      expect(carrier['ot-baggage-umbrella']).to eq('golf')
+      expect(carrier['ot-baggage-unsafeheader']).to be_nil
+      expect(carrier['ot-baggage-CASE-Sensitivity_Underscores']).to eq('value')
+    end
+
+    it 'propagates an 8 byte trace id' do
+      carrier = {}
+      propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
+
+      expect(carrier['ot-tracer-traceid']).to eq(trace_id)
+      expect(carrier['ot-tracer-traceid'].size).to eq(16)
+    end
+
+    it 'always propagates a true sampled flag' do
+      [true, false].each do |sampled|
+        ctx = LightStep::SpanContext.new(
+          id: span_id,
+          trace_id: trace_id,
+          sampled: sampled,
+          baggage: baggage
+        )
+        carrier = {}
+        propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
+        expect(carrier['ot-tracer-sampled']).to eq('true')
+      end
     end
   end
 
-  it 'always extracts a true sampled flag' do
-    ['true', 'false'].each do |sampled|
-       carrier = {
-          'ot-tracer-traceid' => trace_id,
-          'ot-tracer-spanid' => span_id,
-          'ot-tracer-sampled' => sampled
-        }
+  describe '#extract' do
+    it 'handles text carriers' do
+      carrier = {}
+      propagator.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
+      extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+
+      expect(extracted_ctx.trace_id).to eq(trace_id)
+      expect(extracted_ctx.trace_id16).to eq(padded_trace_id)
+      expect(extracted_ctx.id).to eq(span_id)
+      expect(extracted_ctx.baggage['footwear']).to eq('cleats')
+      expect(extracted_ctx.baggage['umbrella']).to eq('golf')
+    end
+
+    it 'handles rack carriers' do
+      baggage.merge!({
+        'unsafe!@#$%$^&header' => 'value',
+        'CASE-Sensitivity_Underscores'=> 'value'
+      })
+
+      carrier = {}
+      propagator.inject(span_context, OpenTracing::FORMAT_RACK, carrier)
+      extracted_ctx = propagator.extract(OpenTracing::FORMAT_RACK, to_rack_env(carrier))
+
+      expect(extracted_ctx.trace_id).to eq(trace_id)
+      expect(extracted_ctx.trace_id16).to eq(padded_trace_id)
+      expect(extracted_ctx.id).to eq(span_id)
+      expect(extracted_ctx.baggage['footwear']).to eq('cleats')
+      expect(extracted_ctx.baggage['umbrella']).to eq('golf')
+      expect(extracted_ctx.baggage['unsafe!@#$%$^&header']).to be_nil
+      expect(extracted_ctx.baggage['unsafeheader']).to be_nil
+      expect(extracted_ctx.baggage['case-sensitivity-underscores']).to eq('value')
+    end
+
+    it 'returns a span context when carrier has both a span_id and trace_id' do
+      extracted_ctx = propagator.extract(
+        OpenTracing::FORMAT_RACK,
+        {'HTTP_OT_TRACER_TRACEID' => trace_id}
+      )
+
+      expect(extracted_ctx).to be_nil
+      extracted_ctx = propagator.extract(
+        OpenTracing::FORMAT_RACK,
+        {'HTTP_OT_TRACER_SPANID' => span_id}
+      )
+      expect(extracted_ctx).to be_nil
+
+      # We need both a TRACEID and SPANID; this has both so it should work.
+      extracted_ctx = propagator.extract(
+        OpenTracing::FORMAT_RACK,
+        {'HTTP_OT_TRACER_SPANID' => span_id, 'HTTP_OT_TRACER_TRACEID' => trace_id}
+      )
+      expect(extracted_ctx.id).to eq(span_id)
+      expect(extracted_ctx.trace_id).to eq(trace_id)
+      expect(extracted_ctx.trace_id16).to eq(padded_trace_id)
+    end
+
+    it 'handles carriers with string keys' do
+      carrier = {
+        'HTTP_OT_TRACER_TRACEID' => trace_id,
+        'HTTP_OT_TRACER_SPANID' => span_id,
+      }
+      extracted_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier)
+
+      expect(extracted_ctx).not_to be_nil
+      expect(extracted_ctx.trace_id).to eq(trace_id)
+      expect(extracted_ctx.trace_id16).to eq(padded_trace_id)
+      expect(extracted_ctx.id).to eq(span_id)
+    end
+
+    it 'handles carriers with symbol keys' do
+      carrier = {
+        HTTP_OT_TRACER_TRACEID: trace_id,
+        HTTP_OT_TRACER_SPANID: span_id,
+      }
+      extracted_ctx = propagator.extract(OpenTracing::FORMAT_RACK, carrier)
+
+      expect(extracted_ctx).not_to be_nil
+      expect(extracted_ctx.trace_id).to eq(trace_id)
+      expect(extracted_ctx.trace_id16).to eq(padded_trace_id)
+      expect(extracted_ctx.id).to eq(span_id)
+    end
+
+    it 'maintains 8 and 16 byte trace ids' do
+      trace_id16 = [LightStep.guid, trace_id].join
+
+      carrier = {
+        'ot-tracer-traceid' => trace_id16,
+        'ot-tracer-spanid' => span_id,
+        'ot-tracer-sampled' => 'true'
+      }
 
       extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
-      expect(extracted_ctx).to be_sampled
+      expect(extracted_ctx.trace_id16).to eq(trace_id16)
+      expect(extracted_ctx.trace_id16.size).to eq(32)
+      expect(extracted_ctx.trace_id).to eq(trace_id)
+      expect(extracted_ctx.trace_id.size).to eq(16)
     end
-  end
 
-  def to_rack_env(input_hash)
-    input_hash.inject({}) do |memo, (k, v)|
-      memo[to_rack_key(k)] = v
-      memo
+    it 'always sets sampled: true on returned context' do
+      ['true', 'false'].each do |sampled|
+         carrier = {
+            'ot-tracer-traceid' => trace_id,
+            'ot-tracer-spanid' => span_id,
+            'ot-tracer-sampled' => sampled
+          }
+
+        extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+        expect(extracted_ctx).to be_sampled
+      end
     end
-  end
-
-  def to_rack_key(key)
-    "HTTP_#{key.gsub("-", "_").upcase!}"
   end
 end

--- a/spec/lightstep/propagation_spec.rb
+++ b/spec/lightstep/propagation_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe LightStep::Propagation do
+  let(:propagator_map) { LightStep::Propagation::PROPAGATOR_MAP }
+  describe "[]" do
+    it 'returns propagator instance from symbol' do
+      propagator_map.each_pair do |sym, klass|
+        propagator = LightStep::Propagation[sym]
+        expect(propagator).to be_an_instance_of(klass)
+      end
+    end
+
+    it 'returns propagator instance from a string' do
+      propagator_map.each_pair do |sym, klass|
+        propagator = LightStep::Propagation[sym.to_s]
+        expect(propagator).to be_an_instance_of(klass)
+      end
+    end
+
+    it 'returns lightstep propagator when name is unknown' do
+      propagator = LightStep::Propagation[:this_propagator_is_unknown]
+      expect(propagator).to be_an_instance_of(LightStep::Propagation::LightStepPropagator)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,9 +20,11 @@ SimpleCov.start
 require 'pp'
 require 'lightstep'
 require 'timecop'
+require 'helpers/rack_helpers'
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.include RackHelpers, :rack_helpers
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
This PR adds support for B3 context propagation. A user is able to specify a propagator instance during tracer initialization. The default propagation format is LightStep. See the example below:

```ruby
# Use default (LightStep) propagation
LightStep.configure(component_name: 'lightstep/ruby/example', access_token: 'your_access_token',)

#Specify B3 propagation
LightStep.configure(component_name: 'lightstep/ruby/example', access_token: 'your_access_token', propagator: :b3)
```

**Currently Implemented**
* B3 Multiple Header format
* Propagates sampling flag

**Not Implemented**
* B3 debug trace flag
* Single header version

This work might be incomplete, however, I figured I'd open this PR as a starting point for discussion as it's somewhat unclear what level of support is required. The current [javascript PR](https://github.com/lightstep/lightstep-tracer-javascript/pull/177) implements the multiple header format, does not propagate the sampled state, or implement the debug flag or single header format. The [python PR](https://github.com/lightstep/lightstep-tracer-python/pull/80) is the most complete and as it implements both multiple and single header formats, propagates the sampled state and debug trace flag.

