### PR TITLE
Propagate sampled flag in-process and improve docs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v0.16.0
 ### Added
-- The tracer now supports B3 context propagation. Propagation can be set by using the `propagator` keyword argument to `Tracer#configure`. Valid values are `:lightstep` (default), and `:b3`.
+- The tracer now supports B3 context propagation. Propagation can be set by using the `propagator` keyword argument to `LightStep.configure`. Valid values are `:lightstep` (default), and `:b3`.
 
 ## v0.15.0
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Or install it yourself as:
     LightStep.configure(component_name: 'lightstep/ruby/example', access_token: 'your_access_token')
 
     # Specify a propagation format (options are :lightstep (default) and :b3)
-    LightStep.configure(component_name: 'lightstep/ruby/example', access_token: 'your_access_token', :propagator :b3)
+    LightStep.configure(component_name: 'lightstep/ruby/example', access_token: 'your_access_token', propagator: :b3)
 
     # Create a basic span and attach a log to the span
     span = LightStep.start_span('my_span')

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Or install it yourself as:
     # Initialize the singleton tracer
     LightStep.configure(component_name: 'lightstep/ruby/example', access_token: 'your_access_token')
 
+    # Specify a propagation format (options are :lightstep (default) and :b3)
+    LightStep.configure(component_name: 'lightstep/ruby/example', access_token: 'your_access_token', :propagator :b3)
+
     # Create a basic span and attach a log to the span
     span = LightStep.start_span('my_span')
     span.log(event: 'hello world', count: 42)

--- a/lib/lightstep/span.rb
+++ b/lib/lightstep/span.rb
@@ -56,7 +56,7 @@ module LightStep
       ref = ref.context if (Span === ref)
 
       if SpanContext === ref
-        @context = SpanContext.new(id: LightStep.guid, trace_id: ref.trace_id)
+        @context = SpanContext.new(id: LightStep.guid, trace_id: ref.trace_id, sampled: ref.sampled?)
         set_baggage(ref.baggage)
         set_tag(:parent_span_guid, ref.id)
       else
@@ -83,6 +83,7 @@ module LightStep
       @context = SpanContext.new(
         id: context.id,
         trace_id: context.trace_id,
+        sampled: context.sampled?,
         baggage: context.baggage.merge({key => value})
       )
       self
@@ -94,6 +95,7 @@ module LightStep
       @context = SpanContext.new(
         id: context.id,
         trace_id: context.trace_id,
+        sampled: context.sampled?,
         baggage: baggage
       )
     end

--- a/lib/lightstep/span_context.rb
+++ b/lib/lightstep/span_context.rb
@@ -20,12 +20,12 @@ module LightStep
 
     def truncate_id(id)
       return id unless id && id.size == 32
-      id[16..-1]
+      id[0...16]
     end
 
     def pad_id(id)
       return id unless id && id.size == 16
-      "#{ZERO_PADDING}#{id}"
+      "#{id}#{ZERO_PADDING}"
     end
   end
 end

--- a/spec/lightstep/propagation/lightstep_propagator_spec.rb
+++ b/spec/lightstep/propagation/lightstep_propagator_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe LightStep::Propagation::LightStepPropagator, :rack_helpers do
   let(:propagator) { subject }
   let(:trace_id) { LightStep.guid }
-  let(:padded_trace_id) { '0' * 16 << trace_id }
+  let(:padded_trace_id) { trace_id + '0' * 16 }
   let(:span_id) { LightStep.guid }
   let(:baggage) do
     {
@@ -153,7 +153,7 @@ describe LightStep::Propagation::LightStepPropagator, :rack_helpers do
     end
 
     it 'maintains 8 and 16 byte trace ids' do
-      trace_id16 = [LightStep.guid, trace_id].join
+      trace_id16 = [trace_id, LightStep.guid].join
 
       carrier = {
         'ot-tracer-traceid' => trace_id16,

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -72,6 +72,20 @@ describe LightStep do
     expect(child_span.span_context.baggage).to eq(parent_span.span_context.baggage)
   end
 
+  it 'should inherit true sampled flag from parent span' do
+    tracer = init_test_tracer
+    parent_ctx = LightStep::SpanContext.new(id: LightStep.guid, trace_id: LightStep.guid, sampled: true)
+    child_span = tracer.start_span('child_span', child_of: parent_ctx)
+    expect(child_span.span_context).to be_sampled
+  end
+
+  it 'should inherit false sampled flag from parent span' do
+    tracer = init_test_tracer
+    parent_ctx = LightStep::SpanContext.new(id: LightStep.guid, trace_id: LightStep.guid, sampled: false)
+    child_span = tracer.start_span('child_span', child_of: parent_ctx)
+    expect(child_span.span_context).not_to be_sampled
+  end
+
   it 'should allow operation_name updates' do
     tracer = init_test_tracer
     span = tracer.start_span('original')


### PR DESCRIPTION
#86 added support for B3 and handles the sampling flag properly at inject and extract sites, but the sampling flag wasn't being propagated properly in-process. This PR fixes that and improves the docs around configuring custom propagation format.