### PR TITLE
ensure scope and span are properly cleaned up in the event of an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-## v0.16.1
-### Bugfix
-- The tracer now closes the active scope or finishes the active span even if an error is raised from the yielded code.
 
 ## v0.16.0
 ### Added
 - The tracer now supports B3 context propagation. Propagation can be set by using the `propagator` keyword argument to `LightStep.configure`. Valid values are `:lightstep` (default), and `:b3`.
+- The tracer now closes the active scope or finishes the active span even if an error is raised from the yielded code.
 
 ## v0.15.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## v0.16.1
+### Bugfix
+- The tracer now closes the active scope or finishes the active span even if an error is raised from the yielded code.
 
 ## v0.16.0
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lightstep (0.16.1)
+    lightstep (0.16.0)
       concurrent-ruby (~> 1.0)
       opentracing (~> 0.5.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lightstep (0.15.0)
+    lightstep (0.16.1)
       concurrent-ruby (~> 1.0)
       opentracing (~> 0.5.0)
 

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -127,7 +127,9 @@ module LightStep
 
       scope_manager.activate(span: span, finish_on_close: finish_on_close).tap do |scope|
         if block_given?
-          return yield(scope).tap do
+          begin
+            return yield scope
+          ensure
             scope.close
           end
         end
@@ -181,7 +183,9 @@ module LightStep
 
       Span.new(span_options).tap do |span|
         if block_given?
-          return yield(span).tap do
+          begin
+            return yield span
+          ensure
             span.finish
           end
         end

--- a/lib/lightstep/version.rb
+++ b/lib/lightstep/version.rb
@@ -1,3 +1,3 @@
 module LightStep
-  VERSION = '0.15.0'.freeze
+  VERSION = '0.16.1'.freeze
 end

--- a/lib/lightstep/version.rb
+++ b/lib/lightstep/version.rb
@@ -1,3 +1,3 @@
 module LightStep
-  VERSION = '0.16.1'.freeze
+  VERSION = '0.16.0'.freeze
 end

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -711,6 +711,19 @@ describe LightStep do
       it 'should finish the span before returning' do
         expect(@span).to have_received(:finish)
       end
+
+      it "should close the span when there is an error" do
+        @span = nil
+        begin
+          tracer.start_span('some-operation') do |span|
+            allow(span).to receive(:finish)
+            @span = span
+            raise StandardError
+          end
+        rescue
+        end
+        expect(@span).to have_received(:finish)
+      end
     end
   end
 
@@ -763,6 +776,19 @@ describe LightStep do
 
       it 'should not finish the span after the block finishes yielding' do
         expect(@scope.span.end_micros).to be_nil
+      end
+
+      it 'closes the scope when there is an error' do
+        @scope = nil
+        begin
+          tracer.start_active_span('some-operation', finish_on_close: false) do |scope|
+            allow(scope).to receive(:close)
+            @scope = scope
+            raise StandardError
+          end
+        rescue StandardError
+        end
+        expect(@scope).to have_received(:close)
       end
     end
 


### PR DESCRIPTION
When spans/scopes aren't closed properly they remain active for the lifetime of the thread.  This can result in a web server treating every single request as part of a single trace because there is always an active span in that thread when the request starts.