### PR TITLE
Prepare v 0.15.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.16.0
-### Added
+## v0.15.1
+### Fixed
 - The tracer now supports B3 context propagation. Propagation can be set by using the `propagator` keyword argument to `LightStep.configure`. Valid values are `:lightstep` (default), and `:b3`.
 - The tracer now closes the active scope or finishes the active span even if an error is raised from the yielded code.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The tracer now supports B3 context propagation. Propagation can be set by using the `propagator` keyword argument to `LightStep.configure`. Valid values are `:lightstep` (default), and `:b3`.
 - The tracer now closes the active scope or finishes the active span even if an error is raised from the yielded code.
 
+### Unreleased
+- In-progress B3 support
+
 ## v0.15.0
 ### Added
 - A Changelog

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lightstep (0.16.0)
+    lightstep (0.15.0)
       concurrent-ruby (~> 1.0)
       opentracing (~> 0.5.0)
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ Or install it yourself as:
     # Initialize the singleton tracer
     LightStep.configure(component_name: 'lightstep/ruby/example', access_token: 'your_access_token')
 
-    # Specify a propagation format (options are :lightstep (default) and :b3)
-    LightStep.configure(component_name: 'lightstep/ruby/example', access_token: 'your_access_token', propagator: :b3)
-
     # Create a basic span and attach a log to the span
     span = LightStep.start_span('my_span')
     span.log(event: 'hello world', count: 42)

--- a/lib/lightstep/propagation.rb
+++ b/lib/lightstep/propagation.rb
@@ -6,15 +6,14 @@ require 'lightstep/propagation/b3_propagator'
 module LightStep
   module Propagation
     PROPAGATOR_MAP = {
-      lightstep: LightStepPropagator,
-      b3: B3Propagator
+      lightstep: LightStepPropagator
     }
 
     class << self
       # Constructs a propagator instance from the given propagator name. If the
       # name is unknown returns the LightStepPropagator as a default
       #
-      # @param [Symbol, String] propagator_name One of :lightstep or :b3
+      # @param [Symbol, String] propagator_name
       # @return [Propagator]
       def [](propagator_name)
         klass = PROPAGATOR_MAP[propagator_name.to_sym] || LightStepPropagator

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -28,7 +28,7 @@ module LightStep
     # @param access_token [String] The project access token when pushing to LightStep
     # @param transport [LightStep::Transport] How the data should be transported
     # @param tags [Hash] Tracer-level tags
-    # @param propagator [Propagator] Symbol one of :lightstep, :b3 indicating the propgator
+    # @param propagator [Propagator] :lightstep is the only supported option
     #   to use
     # @return LightStep::Tracer
     # @raise LightStep::ConfigurationError if the group name or access token is not a valid string.

--- a/lib/lightstep/version.rb
+++ b/lib/lightstep/version.rb
@@ -1,3 +1,3 @@
 module LightStep
-  VERSION = '0.16.0'.freeze
+  VERSION = '0.15.0'.freeze
 end


### PR DESCRIPTION
This PR preps for a v0.15.1 bugfix release. There is some B3 work on master that is not currently ready for use, so this PR removes temporarily removes the Be propagation option. It also resets the version to v0.15.0 because, as far as I know, the publish process will take of the version and tagging for us.