### PR TITLE
Updated B3 trace id handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.16.0
+### Added
+- The tracer now supports B3 context propagation. Propagation can be set by using the `propagator` keyword argument to `LightStep.configure`. Valid values are `:lightstep` (default), and `:b3`.
+
 ## v0.15.1
 ### Fixed
-- The tracer now supports B3 context propagation. Propagation can be set by using the `propagator` keyword argument to `LightStep.configure`. Valid values are `:lightstep` (default), and `:b3`.
 - The tracer now closes the active scope or finishes the active span even if an error is raised from the yielded code.
 
 ### Unreleased

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Or install it yourself as:
     # Initialize the singleton tracer
     LightStep.configure(component_name: 'lightstep/ruby/example', access_token: 'your_access_token')
 
+    # Specify a propagation format (options are :lightstep (default) and :b3)
+    LightStep.configure(component_name: 'lightstep/ruby/example', access_token: 'your_access_token', propagator: :b3)
+
     # Create a basic span and attach a log to the span
     span = LightStep.start_span('my_span')
     span.log(event: 'hello world', count: 42)

--- a/lib/lightstep/propagation.rb
+++ b/lib/lightstep/propagation.rb
@@ -6,14 +6,15 @@ require 'lightstep/propagation/b3_propagator'
 module LightStep
   module Propagation
     PROPAGATOR_MAP = {
-      lightstep: LightStepPropagator
+      lightstep: LightStepPropagator,
+      b3: B3Propagator
     }
 
     class << self
       # Constructs a propagator instance from the given propagator name. If the
       # name is unknown returns the LightStepPropagator as a default
       #
-      # @param [Symbol, String] propagator_name
+      # @param [Symbol, String] propagator_name One of :lightstep or :b3
       # @return [Propagator]
       def [](propagator_name)
         klass = PROPAGATOR_MAP[propagator_name.to_sym] || LightStepPropagator

--- a/lib/lightstep/propagation/b3_propagator.rb
+++ b/lib/lightstep/propagation/b3_propagator.rb
@@ -7,6 +7,7 @@ module LightStep
       CARRIER_SPAN_ID = 'x-b3-spanid'
       CARRIER_TRACE_ID = 'x-b3-traceid'
       CARRIER_SAMPLED = 'x-b3-sampled'
+      TRUE_VALUES = %w[1 true].freeze
 
       private
 
@@ -21,7 +22,7 @@ module LightStep
       end
 
       def sampled_flag_from_carrier(carrier)
-        carrier[self.class::CARRIER_SAMPLED] == '1' ? true : false
+        TRUE_VALUES.include?(carrier[self.class::CARRIER_SAMPLED])
       end
     end
   end

--- a/lib/lightstep/propagation/b3_propagator.rb
+++ b/lib/lightstep/propagation/b3_propagator.rb
@@ -10,8 +10,10 @@ module LightStep
 
       private
 
+      # propagate the full 128-bit trace id if the original id was 128-bit,
+      # use the 64 bit id otherwise
       def trace_id_from_ctx(ctx)
-        ctx.trace_id16
+        ctx.id_truncated? ? ctx.trace_id128 : ctx.trace_id64
       end
 
       def sampled_flag_from_ctx(ctx)

--- a/lib/lightstep/span.rb
+++ b/lib/lightstep/span.rb
@@ -56,7 +56,11 @@ module LightStep
       ref = ref.context if (Span === ref)
 
       if SpanContext === ref
-        @context = SpanContext.new(id: LightStep.guid, trace_id: ref.trace_id, sampled: ref.sampled?)
+        @context = SpanContext.new(
+          id: LightStep.guid,
+          trace_id: ref.trace_id,
+          trace_id_upper64: ref.trace_id_upper64,
+          sampled: ref.sampled?)
         set_baggage(ref.baggage)
         set_tag(:parent_span_guid, ref.id)
       else
@@ -83,6 +87,7 @@ module LightStep
       @context = SpanContext.new(
         id: context.id,
         trace_id: context.trace_id,
+        trace_id_upper64: context.trace_id_upper64,
         sampled: context.sampled?,
         baggage: context.baggage.merge({key => value})
       )
@@ -95,6 +100,7 @@ module LightStep
       @context = SpanContext.new(
         id: context.id,
         trace_id: context.trace_id,
+        trace_id_upper64: context.trace_id_upper64,
         sampled: context.sampled?,
         baggage: baggage
       )

--- a/lib/lightstep/span_context.rb
+++ b/lib/lightstep/span_context.rb
@@ -3,29 +3,43 @@
 module LightStep
   # SpanContext holds the data for a span that gets inherited to child spans
   class SpanContext
-    attr_reader :id, :trace_id, :trace_id16, :sampled, :baggage
+    attr_reader :id, :trace_id, :trace_id_upper64, :sampled, :baggage
+    alias_method :trace_id64, :trace_id
     alias_method :sampled?, :sampled
 
     ZERO_PADDING = '0' * 16
 
-    def initialize(id:, trace_id:, sampled: true, baggage: {})
+    def initialize(id:, trace_id:, trace_id_upper64: nil, sampled: true, baggage: {})
       @id = id.freeze
-      @trace_id16 = pad_id(trace_id).freeze
       @trace_id = truncate_id(trace_id).freeze
+      @trace_id_upper64 = trace_id_upper64 || extended_bits(trace_id).freeze
       @sampled = sampled
       @baggage = baggage.freeze
     end
 
-    private
-
-    def truncate_id(id)
-      return id unless id && id.size == 32
-      id[0...16]
+    # Lazily initializes and returns a 128-bit representation of a 64-bit trace id
+    def trace_id128
+      @trace_id128 ||= "#{trace_id_upper64 || ZERO_PADDING}#{trace_id}"
     end
 
-    def pad_id(id)
-      return id unless id && id.size == 16
-      "#{id}#{ZERO_PADDING}"
+    # Returns true if the original trace_id was 128 bits
+    def id_truncated?
+      !@trace_id_upper64.nil?
+    end
+
+    private
+
+    # Truncates an id to 64 bits
+    def truncate_id(id)
+      return id unless id && id.size == 32
+      id[16..-1]
+    end
+
+    # Returns the most significant 64 bits of a 128 bit id or nil if the id
+    # is 64 bits
+    def extended_bits(id)
+      return unless id && id.size == 32
+      id[0...16]
     end
   end
 end

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -28,7 +28,7 @@ module LightStep
     # @param access_token [String] The project access token when pushing to LightStep
     # @param transport [LightStep::Transport] How the data should be transported
     # @param tags [Hash] Tracer-level tags
-    #v@param propagator [Propagator] Symbol one of :lightstep, :b3 indicating the propgator
+    # @param propagator [Propagator] Symbol one of :lightstep, :b3 indicating the propagator
     #   to use
     # @return LightStep::Tracer
     # @raise LightStep::ConfigurationError if the group name or access token is not a valid string.

--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -28,7 +28,7 @@ module LightStep
     # @param access_token [String] The project access token when pushing to LightStep
     # @param transport [LightStep::Transport] How the data should be transported
     # @param tags [Hash] Tracer-level tags
-    # @param propagator [Propagator] :lightstep is the only supported option
+    #v@param propagator [Propagator] Symbol one of :lightstep, :b3 indicating the propgator
     #   to use
     # @return LightStep::Tracer
     # @raise LightStep::ConfigurationError if the group name or access token is not a valid string.

--- a/spec/lightstep/propagation/b3_propagator_spec.rb
+++ b/spec/lightstep/propagation/b3_propagator_spec.rb
@@ -196,25 +196,29 @@ describe LightStep::Propagation::B3Propagator, :rack_helpers do
     end
 
     it 'interprets a true sampled flag properly' do
-      carrier = {
-        'x-b3-traceid' => trace_id64,
-        'x-b3-spanid' => span_id,
-        'x-b3-sampled' => '1'
-      }
+      %w[1 true].each do |sampled_value|
+        carrier = {
+          'x-b3-traceid' => trace_id64,
+          'x-b3-spanid' => span_id,
+          'x-b3-sampled' => sampled_value
+        }
 
-      extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
-      expect(extracted_ctx).to be_sampled
+        extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+        expect(extracted_ctx).to be_sampled
+      end
     end
 
     it 'interprets a false sampled flag properly' do
-      carrier = {
-        'x-b3-traceid' => trace_id64,
-        'x-b3-spanid' => span_id,
-        'x-b3-sampled' => '0'
-      }
+      %w[0 false].each do |sampled_value|
+        carrier = {
+          'x-b3-traceid' => trace_id64,
+          'x-b3-spanid' => span_id,
+          'x-b3-sampled' => sampled_value
+        }
 
-      extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
-      expect(extracted_ctx).not_to be_sampled
+        extracted_ctx = propagator.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+        expect(extracted_ctx).not_to be_sampled
+      end
     end
   end
 end


### PR DESCRIPTION
This PR updates B3 trace_id handling. The tracer will propagate ids in the format it receives them. If it receives a 128bit id, it will propagate a 128 bit id, but use a truncated 64 bit id internally and when sending data to LightStep. If the tracer initiates a trace, it will generate (and propagate) a 64 bit trace id.

This PR also loosens the interpretation of the sampled flag so that `1` and `true` will be considered `true` and `0` and `false` will be considered `false`. While only sampling values of `0` and `1` are officially supported, the B3 spec says a lenient implementation will also interpret the `true` and `false` versions of the flag properly. 

As a side note, while padding is no longer being used for B3, its implementation was left intact since we will need it for W3C trace context.